### PR TITLE
W-18921869 Warning for flexcard with Navigate URL

### DIFF
--- a/messages/assess.json
+++ b/messages/assess.json
@@ -183,5 +183,6 @@
   "missingInfo": "Info is missing",
   "errorCheckingGlobalAutoNumber": "We couldn’t check whether the Global Auto Number setting is enabled: %s. Try again later.",
   "errorMigrationMessage": "Error migrating object: %s",
-  "nameMappingUndefined": "Name Mapping is undefined"
+  "nameMappingUndefined": "Name Mapping is undefined",
+  "webPageOmniScriptNavigationDetected": "Web page omniscript navigate url needs manual intervention"
 }

--- a/messages/migrate.json
+++ b/messages/migrate.json
@@ -198,5 +198,6 @@
   "incompleteMigrationDetected": "We couldn’t complete the migration process",
   "errorCheckingGlobalAutoNumber": "We couldn’t check whether the Global Auto Number setting is enabled: %s. Try again later.",
   "errorMigrationMessage": "Error migrating object: %s",
-  "nameMappingUndefined": "Name Mapping is undefined"
+  "nameMappingUndefined": "Name Mapping is undefined",
+  "webPageOmniScriptNavigationDetected": "Web page omniscript navigate url needs manual intervention"
 }

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -395,6 +395,21 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
               }
             }
           }
+
+          // Case 3: Web Page navigation
+          else if (action.stateAction.targetType === 'Web Page' && action.stateAction['Web Page']) {
+            const webPage = action.stateAction['Web Page'];
+            if (webPage.targetName) {
+              // Check if the targetName contains OmniScript wrapper references
+              const targetName = webPage.targetName;
+              if (this.isOmniScriptNavigationUrl(targetName)) {
+                flexCardAssessmentInfo.warnings.push(
+                  this.messages.getMessage('webPageOmniScriptNavigationDetected', [targetName])
+                );
+                flexCardAssessmentInfo.migrationStatus = 'Need Manual Intervention';
+              }
+            }
+          }
         }
       }
     }
@@ -897,5 +912,21 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
 
   private getCardFields(): string[] {
     return Object.keys(CardMappings);
+  }
+
+  /**
+   * Check if a URL is an OmniScript navigation URL
+   * @param url The URL to check
+   * @returns true if the URL contains OmniScript wrapper references
+   */
+  private isOmniScriptNavigationUrl(url: string): boolean {
+    if (!url || typeof url !== 'string') {
+      return false;
+    }
+
+    // Check for common OmniScript wrapper patterns
+    const omniScriptPatterns = ['c__target=c:', '/lightning/cmp/', 'c__layout=lightning'];
+
+    return omniScriptPatterns.some((pattern) => url.includes(pattern));
   }
 }


### PR DESCRIPTION
### What does this PR do?
<img width="1572" height="281" alt="image" src="https://github.com/user-attachments/assets/62e42e85-d44e-455d-93ef-b59bc8dfbbcb" />


### What issues does this PR fix or reference?
Flexcards can contain the navigate action which can have Omniscript URL. But since the migration happens in sandbox org and later the customer deploys the metadata to some other org, so we have decided to go ahead with displaying warning to notify the customer that manual intervention is required for them to handle the url.

