### PR TITLE
@W-19878784 Update storageUtil for all versions omniscripts and flexcards

### DIFF
--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -937,7 +937,7 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
 
     for (let flexCardAssessmentInfo of flexcardAssessmentInfos) {
       try {
-        if (!flexCardAssessmentInfo.nameMapping) {
+        if (!flexCardAssessmentInfo?.nameMapping) {
           Logger.error(this.messages.getMessage('missingInfo'));
           return;
         }

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -937,19 +937,17 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
 
     for (let flexCardAssessmentInfo of flexcardAssessmentInfos) {
       try {
-        if (
-          flexCardAssessmentInfo === undefined ||
-          flexCardAssessmentInfo === null ||
-          flexCardAssessmentInfo.nameMapping === undefined ||
-          flexCardAssessmentInfo.nameMapping === null
-        ) {
+        if (!flexCardAssessmentInfo.nameMapping) {
           Logger.error(this.messages.getMessage('missingInfo'));
           return;
         }
 
+        const originalName: string = flexCardAssessmentInfo.nameMapping.oldName;
+
         let value: FlexcardStorage = {
           name: flexCardAssessmentInfo.nameMapping.newName,
           isDuplicate: false,
+          originalName: originalName,
         };
 
         if (flexCardAssessmentInfo.errors && flexCardAssessmentInfo.errors.length > 0) {
@@ -958,23 +956,48 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
         } else {
           value.migrationSuccess = true;
         }
-        let finalKey = `${flexCardAssessmentInfo.nameMapping.oldName}`;
-        finalKey = finalKey.toLowerCase();
-        if (storage.fcStorage.has(finalKey)) {
-          // Key already exists - handle accordingly
-          Logger.logVerbose(this.messages.getMessage('keyAlreadyInStorage', ['Flexcard', finalKey]));
-          value.isDuplicate = true;
-          storage.fcStorage.set(finalKey, value);
-        } else {
-          // Key doesn't exist - safe to set
-          storage.fcStorage.set(finalKey, value);
-        }
+        this.addKeyToStorage(originalName, value, storage);
       } catch (error) {
         Logger.logVerbose(this.messages.getMessage('errorWhileProcessingFlexcardStorage'));
         Logger.error(error);
       }
     }
     StorageUtil.printAssessmentStorage();
+  }
+
+  private addKeyToStorage(originalName: string, value: FlexcardStorage, storage: MigrationStorage) {
+    let finalKey = `${originalName}`;
+    finalKey = finalKey.toLowerCase();
+
+    if (storage.fcStorage.has(finalKey)) {
+      if (this.allVersions) {
+        const storedValue = storage.fcStorage.get(finalKey);
+        if (this.isDifferentFlexcard(storedValue, originalName)) {
+          // same version, no need to do anything
+        } else {
+          this.markDuplicateKeyInStorage(value, finalKey, storage);
+        }
+      } else {
+        this.markDuplicateKeyInStorage(value, finalKey, storage);
+      }
+    } else {
+      // Key doesn't exist - safe to set
+      storage.fcStorage.set(finalKey, value);
+    }
+  }
+
+  private markDuplicateKeyInStorage(value: FlexcardStorage, finalKey: string, storage: MigrationStorage) {
+    // Key already exists - handle accordingly
+    Logger.logVerbose(this.messages.getMessage('keyAlreadyInStorage', ['Flexcard', finalKey]));
+    value.isDuplicate = true;
+    storage.fcStorage.set(finalKey, value);
+  }
+
+  isDifferentFlexcard(storedValue: FlexcardStorage, originalName: string) {
+    if (storedValue.originalName === originalName) {
+      return false;
+    }
+    return true;
   }
 
   private prepareStorageForFlexcards(
@@ -989,9 +1012,11 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
         let oldrecord = originalRecords.get(key);
         let newrecord = cardsUploadInfo.get(key);
 
+        const originalName: string = oldrecord['Name'];
         let value: FlexcardStorage = {
           name: newrecord?.newName,
           isDuplicate: false,
+          originalName: originalName,
         };
 
         if (newrecord === undefined) {
@@ -1005,17 +1030,7 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
           }
         }
 
-        let finalKey = `${oldrecord['Name']}`;
-        finalKey = finalKey.toLowerCase();
-        if (storage.fcStorage.has(finalKey)) {
-          // Key already exists - handle accordingly
-          Logger.logVerbose(this.messages.getMessage('keyAlreadyInStorage', ['Flexcard', finalKey]));
-          value.isDuplicate = true;
-          storage.fcStorage.set(finalKey, value);
-        } else {
-          // Key doesn't exist - safe to set
-          storage.fcStorage.set(finalKey, value);
-        }
+        this.addKeyToStorage(originalName, value, storage);
       } catch (error) {
         Logger.logVerbose(this.messages.getMessage('errorWhileProcessingFlexcardStorage'));
         Logger.error(error);

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -973,8 +973,6 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
       if (this.allVersions) {
         const storedValue = storage.fcStorage.get(finalKey);
         if (this.isDifferentFlexcard(storedValue, originalName)) {
-          // same version, no need to do anything
-        } else {
           this.markDuplicateKeyInStorage(value, finalKey, storage);
         }
       } else {

--- a/src/migration/interfaces.ts
+++ b/src/migration/interfaces.ts
@@ -197,10 +197,14 @@ export interface OmniScriptStorage extends Storage {
   type: string;
   subtype: string;
   language: string;
+  originalType: string;
+  orignalSubtype: string;
+  originalLanguage: string;
 }
 
 export interface FlexcardStorage extends Storage {
   name: string;
+  originalName: string;
 }
 
 export class InvalidEntityTypeError extends Error {

--- a/src/migration/interfaces.ts
+++ b/src/migration/interfaces.ts
@@ -198,7 +198,7 @@ export interface OmniScriptStorage extends Storage {
   subtype: string;
   language: string;
   originalType: string;
-  orignalSubtype: string;
+  originalSubtype: string;
   originalLanguage: string;
 }
 

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -641,7 +641,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
         }
 
         const originalType: string = nameMapping.oldType;
-        const orignalSubtype: string = nameMapping.oldSubtype;
+        const originalSubtype: string = nameMapping.oldSubtype;
         const originalLanguage: string = nameMapping.oldLanguage;
 
         let value: OmniScriptStorage = {
@@ -650,7 +650,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
           language: nameMapping.newLanguage,
           isDuplicate: false,
           originalType: originalType,
-          orignalSubtype: orignalSubtype,
+          originalSubtype: originalSubtype,
           originalLanguage: originalLanguage,
         };
 
@@ -661,7 +661,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
           value.migrationSuccess = true;
         }
 
-        this.addKeyToStorage(originalType, orignalSubtype, originalLanguage, storage, value);
+        this.addKeyToStorage(originalType, originalSubtype, originalLanguage, storage, value);
       } catch (error) {
         Logger.error(error);
       }
@@ -672,7 +672,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
 
   private addKeyToStorage(
     originalType: string,
-    orignalSubtype: string,
+    originalSubtype: string,
     originalLanguage: string,
     storage: MigrationStorage,
     value: OmniScriptStorage
@@ -681,18 +681,18 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
       // Create object key for new storage format
       const keyObject: OmniScriptStandardKey = {
         type: originalType,
-        subtype: orignalSubtype,
+        subtype: originalSubtype,
         language: originalLanguage,
       };
       StorageUtil.addStandardOmniScriptToStorage(storage, keyObject, value);
     }
 
-    let finalKey = `${originalType}${orignalSubtype}${this.cleanLanguageName(originalLanguage)}`;
+    let finalKey = `${originalType}${originalSubtype}${this.cleanLanguageName(originalLanguage)}`;
     finalKey = finalKey.toLowerCase();
     if (storage.osStorage.has(finalKey)) {
       if (this.allVersions) {
         const storedValue = storage.osStorage.get(finalKey);
-        if (this.isDifferentOmniscript(storedValue, originalType, orignalSubtype, originalLanguage)) {
+        if (this.isDifferentOmniscript(storedValue, originalType, originalSubtype, originalLanguage)) {
           this.markDuplicateKeyInStorage(value, finalKey, storage);
         }
       } else {
@@ -713,7 +713,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
   private isDifferentOmniscript(storedValue, type, subtype, language) {
     if (
       storedValue.originalType === type &&
-      storedValue.originalSubType === subtype &&
+      storedValue.originalSubtype === subtype &&
       storedValue.originalLanguage === language
     ) {
       return false;
@@ -1204,7 +1204,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
             language: newrecord['language'],
             isDuplicate: false,
             originalType: oldrecord[this.getFieldKey('Type__c')],
-            orignalSubtype: oldrecord[this.getFieldKey('SubType__c')],
+            originalSubtype: oldrecord[this.getFieldKey('SubType__c')],
             originalLanguage: oldrecord[this.getFieldKey('Language__c')],
           };
 

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -654,8 +654,11 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
           originalLanguage: originalLanguage,
         };
 
-        if (currentOsRecordInfo.errors && currentOsRecordInfo.errors.length > 0) {
-          value.error = currentOsRecordInfo.errors;
+        if (
+          (currentOsRecordInfo.errors && currentOsRecordInfo.errors.length > 0) ||
+          currentOsRecordInfo.migrationStatus === 'Needs Manual Intervention'
+        ) {
+          value.error = [...(currentOsRecordInfo.errors || []), ...(currentOsRecordInfo.warnings || [])];
           value.migrationSuccess = false;
         } else {
           value.migrationSuccess = true;
@@ -1212,8 +1215,8 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
           if (newrecord === undefined) {
             value.migrationSuccess = false;
           } else {
-            if (newrecord.hasErrors) {
-              value.error = newrecord.errors;
+            if (newrecord.hasErrors || newrecord.success === false) {
+              value.error = [...(newrecord.errors || []), ...(newrecord.warnings || [])];
               value.migrationSuccess = false;
             } else {
               value.migrationSuccess = true;

--- a/test/migration/related/ExperienceSiteMigration.test.ts
+++ b/test/migration/related/ExperienceSiteMigration.test.ts
@@ -267,8 +267,11 @@ describe('ExperienceSiteMigration', () => {
 
       const mockOSStorage: OmniScriptStorage = {
         type: 'TestType',
+        originalType: 'TestType',
         subtype: 'TestSubtype',
+        originalSubtype: 'TestSubtype',
         language: 'English',
+        originalLanguage: 'English',
         isDuplicate: false,
         migrationSuccess: true,
       };
@@ -352,8 +355,11 @@ describe('ExperienceSiteMigration', () => {
 
       const failedOSStorage: OmniScriptStorage = {
         type: 'TestType',
+        originalType: 'TestType',
         subtype: 'TestSubtype',
+        originalSubtype: 'TestSubtype',
         language: 'English',
+        originalLanguage: 'English',
         isDuplicate: false,
         migrationSuccess: false,
       };
@@ -380,8 +386,11 @@ describe('ExperienceSiteMigration', () => {
 
       const duplicateOSStorage: OmniScriptStorage = {
         type: 'TestType',
+        originalType: 'TestType',
         subtype: 'TestSubtype',
+        originalSubtype: 'TestSubtype',
         language: 'English',
+        originalLanguage: 'English',
         isDuplicate: true,
         migrationSuccess: true,
       };
@@ -453,8 +462,11 @@ describe('ExperienceSiteMigration', () => {
 
       const mockOSStorage: OmniScriptStorage = {
         type: 'TestType',
+        originalType: 'TestType',
         subtype: 'TestSubtype',
+        originalSubtype: 'TestSubtype',
         language: 'English',
+        originalLanguage: 'English',
         isDuplicate: false,
         migrationSuccess: true,
       };
@@ -513,8 +525,11 @@ describe('ExperienceSiteMigration', () => {
 
       const mockOSStorage: OmniScriptStorage = {
         type: 'TestType',
+        originalType: 'TestType',
         subtype: 'TestSubtype',
+        originalSubtype: 'TestSubtype',
         language: 'English',
+        originalLanguage: 'English',
         isDuplicate: false,
         migrationSuccess: true,
       };
@@ -562,8 +577,11 @@ describe('ExperienceSiteMigration', () => {
 
       const failedOSStorage: OmniScriptStorage = {
         type: 'FailedType',
+        originalType: 'FailedType',
         subtype: 'FailedSubtype',
+        originalSubtype: 'FailedSubtype',
         language: 'English',
+        originalLanguage: 'English',
         isDuplicate: false,
         migrationSuccess: false,
       };
@@ -591,8 +609,11 @@ describe('ExperienceSiteMigration', () => {
 
       const duplicateOSStorage: OmniScriptStorage = {
         type: 'DuplicateType',
+        originalType: 'DuplicateType',
         subtype: 'DuplicateSubtype',
+        originalSubtype: 'DuplicateSubtype',
         language: 'English',
+        originalLanguage: 'English',
         isDuplicate: true,
         migrationSuccess: true,
       };
@@ -640,16 +661,22 @@ describe('ExperienceSiteMigration', () => {
       // One successful, one duplicate
       const successfulStorage: OmniScriptStorage = {
         type: 'SuccessType',
+        originalType: 'SuccessType',
         subtype: 'SuccessSubtype',
+        originalSubtype: 'SuccessSubtype',
         language: 'English',
+        originalLanguage: 'English',
         isDuplicate: false,
         migrationSuccess: true,
       };
 
       const duplicateStorage: OmniScriptStorage = {
         type: 'DuplicateType',
+        originalType: 'DuplicateType',
         subtype: 'DuplicateSubtype',
+        originalSubtype: 'DuplicateSubtype',
         language: 'English',
+        originalLanguage: 'English',
         isDuplicate: true,
         migrationSuccess: true,
       };
@@ -787,8 +814,11 @@ describe('ExperienceSiteMigration', () => {
 
       const mockOSStandardStorage: OmniScriptStorage = {
         type: 'UpdatedType',
+        originalType: 'UpdatedType',
         subtype: 'UpdatedSubtype',
+        originalSubtype: 'UpdatedSubtype',
         language: 'Spanish',
+        originalLanguage: 'Spanish',
         isDuplicate: false,
         migrationSuccess: true,
       };
@@ -892,6 +922,7 @@ describe('ExperienceSiteMigration', () => {
 
       const mockFlexCardStorage = {
         name: 'UpdatedFlexCard',
+        originalName: 'TestFlexCard',
         isDuplicate: false,
         migrationSuccess: true,
       };

--- a/test/migration/storage-duplicate-logic.test.ts
+++ b/test/migration/storage-duplicate-logic.test.ts
@@ -1,0 +1,849 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
+import { expect } from 'chai';
+import { StorageUtil } from '../../src/utils/storageUtil';
+import { OmniScriptMigrationTool, OmniScriptExportType } from '../../src/migration/omniscript';
+import { CardMigrationTool } from '../../src/migration/flexcard';
+import { NameMappingRegistry } from '../../src/migration/NameMappingRegistry';
+import { initializeDataModelService } from '../../src/utils/dataModelService';
+import { OmnistudioOrgDetails } from '../../src/utils/orgUtils';
+
+describe('Storage Duplicate Logic - Multiple Versions Handling', () => {
+  let mockConnection: any;
+  let mockMessages: any;
+  let mockUx: any;
+  let mockLogger: any;
+  let nameRegistry: NameMappingRegistry;
+
+  beforeEach(() => {
+    nameRegistry = NameMappingRegistry.getInstance();
+    nameRegistry.clear();
+
+    // Initialize data model service
+    const mockOrgDetails: OmnistudioOrgDetails = {
+      packageDetails: { version: '1.0.0', namespace: 'vlocity_ins' },
+      omniStudioOrgPermissionEnabled: false,
+      orgDetails: { Name: 'Test Org', Id: '00D000000000000' },
+      dataModel: 'Custom',
+      hasValidNamespace: true,
+    };
+    initializeDataModelService(mockOrgDetails);
+
+    // Setup mock objects
+    mockConnection = {
+      query: () => Promise.resolve({ records: [] }),
+    };
+    mockMessages = {
+      getMessage: (key: string, params?: string[]): string => {
+        const messages: Record<string, string> = {
+          updatingStorageForOmniscipt: `Updating storage for ${params?.[0]}`,
+          nameMappingUndefined: 'Name mapping is undefined',
+          keyAlreadyInStorage: `Key already exists in storage for ${params?.[0]}: ${params?.[1]}`,
+          missingInfo: 'Missing information',
+          errorWhileProcessingFlexcardStorage: 'Error while processing FlexCard storage',
+          flexcardStorageProcessingStarted: 'FlexCard storage processing started',
+        };
+        return messages[key] || 'Mock message for testing';
+      },
+    };
+    mockUx = {};
+    mockLogger = {};
+
+    // Reset storage instances to ensure clean state between tests
+    const migrationStorage = StorageUtil.getOmnistudioMigrationStorage();
+    migrationStorage.osStorage.clear();
+    migrationStorage.fcStorage.clear();
+
+    const assessmentStorage = StorageUtil.getOmnistudioAssessmentStorage();
+    assessmentStorage.osStorage.clear();
+    assessmentStorage.fcStorage.clear();
+  });
+
+  describe('OmniScript Storage - Assessment Path', () => {
+    it('should NOT set isDuplicate for same OmniScript with multiple versions', () => {
+      const omniScriptTool = new OmniScriptMigrationTool(
+        OmniScriptExportType.OS,
+        'vlocity_ins',
+        mockConnection,
+        mockLogger,
+        mockMessages,
+        mockUx,
+        true // allVersions = true
+      );
+
+      const osAssessmentInfos = [
+        {
+          name: 'CustomerProfile_AccountView_English_1',
+          oldName: 'CustomerProfile_AccountView_English_1',
+          id: 'op1',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'CustomerProfile',
+            oldSubtype: 'AccountView',
+            oldLanguage: 'English',
+            newType: 'CustomerProfile',
+            newSubType: 'AccountView',
+            newLanguage: 'English',
+          },
+        },
+        {
+          name: 'CustomerProfile_AccountView_English_2',
+          oldName: 'CustomerProfile_AccountView_English_2',
+          id: 'op2',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'CustomerProfile',
+            oldSubtype: 'AccountView',
+            oldLanguage: 'English',
+            newType: 'CustomerProfile',
+            newSubType: 'AccountView',
+            newLanguage: 'English',
+          },
+        },
+      ];
+
+      // Process assessment storage
+      (omniScriptTool as any).updateStorageForOmniscriptAssessment(osAssessmentInfos);
+
+      const storage = StorageUtil.getOmnistudioAssessmentStorage();
+      const key = 'customerprofileaccountviewenglish'; // Lowercase cleaned key
+
+      expect(storage.osStorage.has(key)).to.be.true;
+      const storedValue = storage.osStorage.get(key);
+
+      // Should NOT be marked as duplicate (same OmniScript, different versions)
+      expect(storedValue.isDuplicate).to.be.false;
+      expect(storedValue.originalType).to.equal('CustomerProfile');
+      expect(storedValue.originalSubtype).to.equal('AccountView');
+      expect(storedValue.originalLanguage).to.equal('English');
+    });
+
+    it('should set isDuplicate for DIFFERENT OmniScripts with same lowercased key', () => {
+      const omniScriptTool = new OmniScriptMigrationTool(
+        OmniScriptExportType.OS,
+        'vlocity_ins',
+        mockConnection,
+        mockLogger,
+        mockMessages,
+        mockUx,
+        true // allVersions = true
+      );
+
+      const osAssessmentInfos = [
+        {
+          name: 'Aa_Bb_English_1',
+          oldName: 'Aa_Bb_English_1',
+          id: 'op1',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'Aa', // Type="Aa", Subtype="Bb" -> key="aabbenglish"
+            oldSubtype: 'Bb',
+            oldLanguage: 'English',
+            newType: 'Aa',
+            newSubType: 'Bb',
+            newLanguage: 'English',
+          },
+        },
+        {
+          name: 'AaB_b_English_1',
+          oldName: 'AaB_b_English_1',
+          id: 'op2',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'AaB', // Type="AaB", Subtype="b" -> key="aabbenglish" (SAME KEY!)
+            oldSubtype: 'b',
+            oldLanguage: 'English',
+            newType: 'AaB',
+            newSubType: 'b',
+            newLanguage: 'English',
+          },
+        },
+      ];
+
+      // Process assessment storage
+      (omniScriptTool as any).updateStorageForOmniscriptAssessment(osAssessmentInfos);
+
+      const storage = StorageUtil.getOmnistudioAssessmentStorage();
+      const key = 'aabbenglish'; // Lowercase key - SAME for both!
+
+      expect(storage.osStorage.has(key)).to.be.true;
+      const storedValue = storage.osStorage.get(key);
+
+      // SHOULD be marked as duplicate (different OmniScripts produce same lowercased key)
+      expect(storedValue.isDuplicate).to.be.true;
+    });
+
+    it('should NOT set isDuplicate when allVersions=false for same OmniScript', () => {
+      const omniScriptTool = new OmniScriptMigrationTool(
+        OmniScriptExportType.OS,
+        'vlocity_ins',
+        mockConnection,
+        mockLogger,
+        mockMessages,
+        mockUx,
+        false // allVersions = false (only active version)
+      );
+
+      const osAssessmentInfos = [
+        {
+          name: 'CustomerProfile_AccountView_English_1',
+          oldName: 'CustomerProfile_AccountView_English_1',
+          id: 'op1',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'CustomerProfile',
+            oldSubtype: 'AccountView',
+            oldLanguage: 'English',
+            newType: 'CustomerProfile',
+            newSubType: 'AccountView',
+            newLanguage: 'English',
+          },
+        },
+      ];
+
+      // Process assessment storage
+      (omniScriptTool as any).updateStorageForOmniscriptAssessment(osAssessmentInfos);
+
+      const storage = StorageUtil.getOmnistudioAssessmentStorage();
+      const key = 'customerprofileaccountviewenglish';
+
+      expect(storage.osStorage.has(key)).to.be.true;
+      const storedValue = storage.osStorage.get(key);
+
+      // Should NOT be marked as duplicate (only one version)
+      expect(storedValue.isDuplicate).to.be.false;
+    });
+  });
+
+  describe('OmniScript Storage - Migration Path', () => {
+    it('should NOT set isDuplicate for same OmniScript with multiple versions in migration', () => {
+      const omniScriptTool = new OmniScriptMigrationTool(
+        OmniScriptExportType.OS,
+        'vlocity_ins',
+        mockConnection,
+        mockLogger,
+        mockMessages,
+        mockUx,
+        true // allVersions = true
+      );
+
+      const originalOsRecords = new Map<string, any>();
+      /* eslint-disable camelcase */
+      originalOsRecords.set('op1', {
+        Id: 'op1',
+        vlocity_ins__Type__c: 'CustomerProfile',
+        vlocity_ins__SubType__c: 'AccountView',
+        vlocity_ins__Language__c: 'English',
+        vlocity_ins__IsProcedure__c: false,
+      });
+      originalOsRecords.set('op2', {
+        Id: 'op2',
+        vlocity_ins__Type__c: 'CustomerProfile',
+        vlocity_ins__SubType__c: 'AccountView',
+        vlocity_ins__Language__c: 'English',
+        vlocity_ins__IsProcedure__c: false,
+      });
+      /* eslint-enable camelcase */
+
+      const osUploadInfo = new Map<string, any>();
+      osUploadInfo.set('op1', {
+        type: 'CustomerProfile',
+        subtype: 'AccountView',
+        language: 'English',
+        hasErrors: false,
+      });
+      osUploadInfo.set('op2', {
+        type: 'CustomerProfile',
+        subtype: 'AccountView',
+        language: 'English',
+        hasErrors: false,
+      });
+
+      // Process migration storage
+      (omniScriptTool as any).updateStorageForOmniscript(osUploadInfo, originalOsRecords);
+
+      const storage = StorageUtil.getOmnistudioMigrationStorage();
+      const key = 'customerprofileaccountviewenglish';
+
+      expect(storage.osStorage.has(key)).to.be.true;
+      const storedValue = storage.osStorage.get(key);
+
+      // Should NOT be marked as duplicate (same OmniScript, different versions)
+      expect(storedValue.isDuplicate).to.be.false;
+      expect(storedValue.originalType).to.equal('CustomerProfile');
+      expect(storedValue.originalSubtype).to.equal('AccountView');
+      expect(storedValue.originalLanguage).to.equal('English');
+    });
+
+    it('should set isDuplicate for DIFFERENT OmniScripts with same cleaned key in migration', () => {
+      const omniScriptTool = new OmniScriptMigrationTool(
+        OmniScriptExportType.OS,
+        'vlocity_ins',
+        mockConnection,
+        mockLogger,
+        mockMessages,
+        mockUx,
+        true // allVersions = true
+      );
+
+      const originalOsRecords = new Map<string, any>();
+      /* eslint-disable camelcase */
+      originalOsRecords.set('op1', {
+        Id: 'op1',
+        vlocity_ins__Type__c: 'Aa', // Type="Aa", Subtype="Bb" -> key="aabbenglish"
+        vlocity_ins__SubType__c: 'Bb',
+        vlocity_ins__Language__c: 'English',
+        vlocity_ins__IsProcedure__c: false,
+      });
+      originalOsRecords.set('op2', {
+        Id: 'op2',
+        vlocity_ins__Type__c: 'AaB', // Type="AaB", Subtype="b" -> key="aabbenglish" (SAME KEY!)
+        vlocity_ins__SubType__c: 'b',
+        vlocity_ins__Language__c: 'English',
+        vlocity_ins__IsProcedure__c: false,
+      });
+      /* eslint-enable camelcase */
+
+      const osUploadInfo = new Map<string, any>();
+      osUploadInfo.set('op1', {
+        type: 'Aa',
+        subtype: 'Bb',
+        language: 'English',
+        hasErrors: false,
+      });
+      osUploadInfo.set('op2', {
+        type: 'AaB',
+        subtype: 'b',
+        language: 'English',
+        hasErrors: false,
+      });
+
+      // Process migration storage
+      (omniScriptTool as any).updateStorageForOmniscript(osUploadInfo, originalOsRecords);
+
+      const storage = StorageUtil.getOmnistudioMigrationStorage();
+      const key = 'aabbenglish'; // Lowercase key - SAME for both!
+
+      expect(storage.osStorage.has(key)).to.be.true;
+      const storedValue = storage.osStorage.get(key);
+
+      // SHOULD be marked as duplicate (different OmniScripts produce same lowercased key)
+      expect(storedValue.isDuplicate).to.be.true;
+    });
+  });
+
+  describe('FlexCard Storage - Assessment Path', () => {
+    it('should NOT set isDuplicate for same FlexCard with multiple versions', () => {
+      const cardTool = new CardMigrationTool(
+        'vlocity_ins',
+        mockConnection,
+        mockLogger,
+        mockMessages,
+        mockUx,
+        true // allVersions = true
+      );
+
+      const flexcardAssessmentInfos = [
+        {
+          name: 'CustomerDashboard',
+          oldName: 'CustomerDashboard',
+          id: 'fc1',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesFC: [],
+          dependenciesLWC: [],
+          dependenciesApexRemoteAction: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldName: 'CustomerDashboard',
+            newName: 'CustomerDashboard',
+          },
+        },
+        {
+          name: 'CustomerDashboard',
+          oldName: 'CustomerDashboard',
+          id: 'fc2',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesFC: [],
+          dependenciesLWC: [],
+          dependenciesApexRemoteAction: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldName: 'CustomerDashboard',
+            newName: 'CustomerDashboard',
+          },
+        },
+      ];
+
+      // Process assessment storage
+      (cardTool as any).prepareAssessmentStorageForFlexcards(flexcardAssessmentInfos);
+
+      const storage = StorageUtil.getOmnistudioAssessmentStorage();
+      const key = 'customerdashboard'; // Lowercase key
+
+      expect(storage.fcStorage.has(key)).to.be.true;
+      const storedValue = storage.fcStorage.get(key);
+
+      // Should NOT be marked as duplicate (same FlexCard, different versions)
+      expect(storedValue.isDuplicate).to.be.false;
+      expect(storedValue.originalName).to.equal('CustomerDashboard');
+    });
+
+    it('should set isDuplicate for DIFFERENT FlexCards with same lowercased key', () => {
+      const cardTool = new CardMigrationTool(
+        'vlocity_ins',
+        mockConnection,
+        mockLogger,
+        mockMessages,
+        mockUx,
+        true // allVersions = true
+      );
+
+      const flexcardAssessmentInfos = [
+        {
+          name: 'ABc',
+          oldName: 'ABc',
+          id: 'fc1',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesFC: [],
+          dependenciesLWC: [],
+          dependenciesApexRemoteAction: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldName: 'ABc', // Name="ABc" -> key="abc"
+            newName: 'ABc',
+          },
+        },
+        {
+          name: 'AbC',
+          oldName: 'AbC',
+          id: 'fc2',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesFC: [],
+          dependenciesLWC: [],
+          dependenciesApexRemoteAction: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldName: 'AbC', // Name="AbC" -> key="abc" (SAME KEY!)
+            newName: 'AbC',
+          },
+        },
+      ];
+
+      // Process assessment storage
+      (cardTool as any).prepareAssessmentStorageForFlexcards(flexcardAssessmentInfos);
+
+      const storage = StorageUtil.getOmnistudioAssessmentStorage();
+      const key = 'abc'; // Lowercase key - SAME for both!
+
+      expect(storage.fcStorage.has(key)).to.be.true;
+      const storedValue = storage.fcStorage.get(key);
+
+      // SHOULD be marked as duplicate (different FlexCards produce same lowercased key)
+      expect(storedValue.isDuplicate).to.be.true;
+    });
+
+    it('should NOT set isDuplicate when allVersions=false for same FlexCard', () => {
+      const cardTool = new CardMigrationTool(
+        'vlocity_ins',
+        mockConnection,
+        mockLogger,
+        mockMessages,
+        mockUx,
+        false // allVersions = false (only active version)
+      );
+
+      const flexcardAssessmentInfos = [
+        {
+          name: 'CustomerDashboard',
+          oldName: 'CustomerDashboard',
+          id: 'fc1',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesFC: [],
+          dependenciesLWC: [],
+          dependenciesApexRemoteAction: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldName: 'CustomerDashboard',
+            newName: 'CustomerDashboard',
+          },
+        },
+      ];
+
+      // Process assessment storage
+      (cardTool as any).prepareAssessmentStorageForFlexcards(flexcardAssessmentInfos);
+
+      const storage = StorageUtil.getOmnistudioAssessmentStorage();
+      const key = 'customerdashboard';
+
+      expect(storage.fcStorage.has(key)).to.be.true;
+      const storedValue = storage.fcStorage.get(key);
+
+      // Should NOT be marked as duplicate (only one version)
+      expect(storedValue.isDuplicate).to.be.false;
+    });
+  });
+
+  describe('FlexCard Storage - Migration Path', () => {
+    it('should NOT set isDuplicate for same FlexCard with multiple versions in migration', () => {
+      const cardTool = new CardMigrationTool(
+        'vlocity_ins',
+        mockConnection,
+        mockLogger,
+        mockMessages,
+        mockUx,
+        true // allVersions = true
+      );
+
+      const originalRecords = new Map<string, any>();
+      originalRecords.set('fc1', {
+        Id: 'fc1',
+        Name: 'CustomerDashboard',
+      });
+      originalRecords.set('fc2', {
+        Id: 'fc2',
+        Name: 'CustomerDashboard',
+      });
+
+      const cardsUploadInfo = new Map<string, any>();
+      cardsUploadInfo.set('fc1', {
+        newName: 'CustomerDashboard',
+        hasErrors: false,
+      });
+      cardsUploadInfo.set('fc2', {
+        newName: 'CustomerDashboard',
+        hasErrors: false,
+      });
+
+      // Process migration storage
+      (cardTool as any).prepareStorageForFlexcards(cardsUploadInfo, originalRecords);
+
+      const storage = StorageUtil.getOmnistudioMigrationStorage();
+      const key = 'customerdashboard';
+
+      expect(storage.fcStorage.has(key)).to.be.true;
+      const storedValue = storage.fcStorage.get(key);
+
+      // Should NOT be marked as duplicate (same FlexCard, different versions)
+      expect(storedValue.isDuplicate).to.be.false;
+      expect(storedValue.originalName).to.equal('CustomerDashboard');
+    });
+
+    it('should set isDuplicate for DIFFERENT FlexCards with same lowercased key in migration', () => {
+      const cardTool = new CardMigrationTool(
+        'vlocity_ins',
+        mockConnection,
+        mockLogger,
+        mockMessages,
+        mockUx,
+        true // allVersions = true
+      );
+
+      const originalRecords = new Map<string, any>();
+      originalRecords.set('fc1', {
+        Id: 'fc1',
+        Name: 'ABc', // Name="ABc" -> key="abc"
+      });
+      originalRecords.set('fc2', {
+        Id: 'fc2',
+        Name: 'AbC', // Name="AbC" -> key="abc" (SAME KEY!)
+      });
+
+      const cardsUploadInfo = new Map<string, any>();
+      cardsUploadInfo.set('fc1', {
+        newName: 'ABc',
+        hasErrors: false,
+      });
+      cardsUploadInfo.set('fc2', {
+        newName: 'AbC',
+        hasErrors: false,
+      });
+
+      // Process migration storage
+      (cardTool as any).prepareStorageForFlexcards(cardsUploadInfo, originalRecords);
+
+      const storage = StorageUtil.getOmnistudioMigrationStorage();
+      const key = 'abc'; // Lowercase key - SAME for both!
+
+      expect(storage.fcStorage.has(key)).to.be.true;
+      const storedValue = storage.fcStorage.get(key);
+
+      // SHOULD be marked as duplicate (different FlexCards produce same lowercased key)
+      expect(storedValue.isDuplicate).to.be.true;
+    });
+  });
+
+  describe('Edge Cases and Complex Scenarios', () => {
+    it('should handle multiple versions followed by duplicate from different component', () => {
+      const omniScriptTool = new OmniScriptMigrationTool(
+        OmniScriptExportType.OS,
+        'vlocity_ins',
+        mockConnection,
+        mockLogger,
+        mockMessages,
+        mockUx,
+        true
+      );
+
+      const osAssessmentInfos = [
+        // Version 1 of OmniScript A
+        {
+          name: 'TestType_TestSubType_English_1',
+          oldName: 'TestType_TestSubType_English_1',
+          id: 'op1',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'TestType',
+            oldSubtype: 'TestSubType',
+            oldLanguage: 'English',
+            newType: 'TestType',
+            newSubType: 'TestSubType',
+            newLanguage: 'English',
+          },
+        },
+        // Version 2 of OmniScript A (same original)
+        {
+          name: 'TestType_TestSubType_English_2',
+          oldName: 'TestType_TestSubType_English_2',
+          id: 'op2',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'TestType',
+            oldSubtype: 'TestSubType',
+            oldLanguage: 'English',
+            newType: 'TestType',
+            newSubType: 'TestSubType',
+            newLanguage: 'English',
+          },
+        },
+        // OmniScript B with different original that produces same lowercased key
+        {
+          name: 'TestTypeT_estSubType_English_1',
+          oldName: 'TestTypeT_estSubType_English_1',
+          id: 'op3',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'TestTypeT', // Type="TestTypeT", Subtype="estSubType" -> key="testtypetestsubtypeenglish" (SAME!)
+            oldSubtype: 'estSubType',
+            oldLanguage: 'English',
+            newType: 'TestTypeT',
+            newSubType: 'estSubType',
+            newLanguage: 'English',
+          },
+        },
+      ];
+
+      (omniScriptTool as any).updateStorageForOmniscriptAssessment(osAssessmentInfos);
+
+      const storage = StorageUtil.getOmnistudioAssessmentStorage();
+      const key = 'testtypetestsubtypeenglish'; // Same key for "TestType"+"TestSubType" and "TestTypeT"+"estSubType"
+
+      expect(storage.osStorage.has(key)).to.be.true;
+      const storedValue = storage.osStorage.get(key);
+
+      // Should be marked as duplicate because the third one is a DIFFERENT OmniScript with same key
+      expect(storedValue.isDuplicate).to.be.true;
+    });
+
+    it('should handle language differences correctly for OmniScripts', () => {
+      const omniScriptTool = new OmniScriptMigrationTool(
+        OmniScriptExportType.OS,
+        'vlocity_ins',
+        mockConnection,
+        mockLogger,
+        mockMessages,
+        mockUx,
+        true
+      );
+
+      const osAssessmentInfos = [
+        {
+          name: 'TestType_TestSubType_English_1',
+          oldName: 'TestType_TestSubType_English_1',
+          id: 'op1',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'TestType',
+            oldSubtype: 'TestSubType',
+            oldLanguage: 'English',
+            newType: 'TestType',
+            newSubType: 'TestSubType',
+            newLanguage: 'English',
+          },
+        },
+        {
+          name: 'TestType_TestSubType_French_1',
+          oldName: 'TestType_TestSubType_French_1',
+          id: 'op2',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'TestType',
+            oldSubtype: 'TestSubType',
+            oldLanguage: 'French',
+            newType: 'TestType',
+            newSubType: 'TestSubType',
+            newLanguage: 'French',
+          },
+        },
+      ];
+
+      (omniScriptTool as any).updateStorageForOmniscriptAssessment(osAssessmentInfos);
+
+      const storage = StorageUtil.getOmnistudioAssessmentStorage();
+
+      // Different languages result in different keys
+      const englishKey = 'testtypetestsubtypeenglish';
+      const frenchKey = 'testtypetestsubtypefrench';
+
+      expect(storage.osStorage.has(englishKey)).to.be.true;
+      expect(storage.osStorage.has(frenchKey)).to.be.true;
+
+      // Neither should be marked as duplicate (different languages = different OmniScripts)
+      expect(storage.osStorage.get(englishKey).isDuplicate).to.be.false;
+      expect(storage.osStorage.get(frenchKey).isDuplicate).to.be.false;
+    });
+  });
+});

--- a/test/migration/storage-duplicate-logic.test.ts
+++ b/test/migration/storage-duplicate-logic.test.ts
@@ -845,5 +845,320 @@ describe('Storage Duplicate Logic - Multiple Versions Handling', () => {
       expect(storage.osStorage.get(englishKey).isDuplicate).to.be.false;
       expect(storage.osStorage.get(frenchKey).isDuplicate).to.be.false;
     });
+
+    it('should handle multiple OmniScripts with multiple versions each', () => {
+      // Enable Standard Data Model for this test to populate osStandardStorage
+      const mockStandardOrgDetails: OmnistudioOrgDetails = {
+        packageDetails: { version: '1.0.0', namespace: 'vlocity_ins' },
+        omniStudioOrgPermissionEnabled: true, // Enable Standard Data Model
+        orgDetails: { Name: 'Test Org', Id: '00D000000000000' },
+        dataModel: 'Standard',
+        hasValidNamespace: true,
+      };
+      initializeDataModelService(mockStandardOrgDetails);
+
+      const omniScriptTool = new OmniScriptMigrationTool(
+        OmniScriptExportType.OS,
+        'vlocity_ins',
+        mockConnection,
+        mockLogger,
+        mockMessages,
+        mockUx,
+        true // allVersions = true
+      );
+
+      const osAssessmentInfos = [
+        // Aa/Bb/English - Version 1
+        {
+          name: 'Aa_Bb_English_1',
+          oldName: 'Aa_Bb_English_1',
+          id: 'os1',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'Aa',
+            oldSubtype: 'Bb',
+            oldLanguage: 'English',
+            newType: 'Aa',
+            newSubType: 'Bb',
+            newLanguage: 'English',
+          },
+        },
+        // Aa/Bb/English - Version 2
+        {
+          name: 'Aa_Bb_English_2',
+          oldName: 'Aa_Bb_English_2',
+          id: 'os2',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'Aa',
+            oldSubtype: 'Bb',
+            oldLanguage: 'English',
+            newType: 'Aa',
+            newSubType: 'Bb',
+            newLanguage: 'English',
+          },
+        },
+        // Aa/Bb/English - Version 3
+        {
+          name: 'Aa_Bb_English_3',
+          oldName: 'Aa_Bb_English_3',
+          id: 'os3',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'Aa',
+            oldSubtype: 'Bb',
+            oldLanguage: 'English',
+            newType: 'Aa',
+            newSubType: 'Bb',
+            newLanguage: 'English',
+          },
+        },
+        // Aa$/Bb$/English - Version 1
+        {
+          name: 'Aa_Bb_English_1',
+          oldName: 'Aa$_Bb$_English_1',
+          id: 'os4',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: ['Type changed from Aa$ to Aa', 'SubType changed from Bb$ to Bb'],
+          errors: [
+            'Omniscript with duplicate name, type, subtype, or language found in this org. Modify your Omniscript and try again. Omniscript Aa_Bb_English_1',
+          ],
+          migrationStatus: 'Needs Manual Intervention' as const,
+          nameMapping: {
+            oldType: 'Aa$',
+            oldSubtype: 'Bb$',
+            oldLanguage: 'English',
+            newType: 'Aa',
+            newSubType: 'Bb',
+            newLanguage: 'English',
+          },
+        },
+        // Aa$/Bb$/English - Version 2
+        {
+          name: 'Aa_Bb_English_2',
+          oldName: 'Aa$_Bb$_English_2',
+          id: 'os5',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: ['Type changed from Aa$ to Aa', 'SubType changed from Bb$ to Bb'],
+          errors: [
+            'Omniscript with duplicate name, type, subtype, or language found in this org. Modify your Omniscript and try again. Omniscript Aa_Bb_English_2',
+          ],
+          migrationStatus: 'Needs Manual Intervention' as const,
+          nameMapping: {
+            oldType: 'Aa$',
+            oldSubtype: 'Bb$',
+            oldLanguage: 'English',
+            newType: 'Aa',
+            newSubType: 'Bb',
+            newLanguage: 'English',
+          },
+        },
+        // Aa$/Bb$/English - Version 3
+        {
+          name: 'Aa_Bb_English_3',
+          oldName: 'Aa$_Bb$_English_3',
+          id: 'os6',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: ['Type changed from Aa$ to Aa', 'SubType changed from Bb$ to Bb'],
+          errors: [
+            'Omniscript with duplicate name, type, subtype, or language found in this org. Modify your Omniscript and try again. Omniscript Aa_Bb_English_3',
+          ],
+          migrationStatus: 'Needs Manual Intervention' as const,
+          nameMapping: {
+            oldType: 'Aa$',
+            oldSubtype: 'Bb$',
+            oldLanguage: 'English',
+            newType: 'Aa',
+            newSubType: 'Bb',
+            newLanguage: 'English',
+          },
+        },
+        // AaB/b/English - Version 1
+        {
+          name: 'AaB_b_English_1',
+          oldName: 'AaB_b_English_1',
+          id: 'os7',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'AaB',
+            oldSubtype: 'b',
+            oldLanguage: 'English',
+            newType: 'AaB',
+            newSubType: 'b',
+            newLanguage: 'English',
+          },
+        },
+        // AaB/b/English - Version 2
+        {
+          name: 'AaB_b_English_2',
+          oldName: 'AaB_b_English_2',
+          id: 'os8',
+          type: 'OmniScript',
+          dependenciesIP: [],
+          dependenciesDR: [],
+          dependenciesOS: [],
+          dependenciesRemoteAction: [],
+          dependenciesLWC: [],
+          missingIP: [],
+          missingDR: [],
+          missingOS: [],
+          infos: [],
+          warnings: [],
+          errors: [],
+          migrationStatus: 'Ready for migration' as const,
+          nameMapping: {
+            oldType: 'AaB',
+            oldSubtype: 'b',
+            oldLanguage: 'English',
+            newType: 'AaB',
+            newSubType: 'b',
+            newLanguage: 'English',
+          },
+        },
+      ];
+
+      (omniScriptTool as any).updateStorageForOmniscriptAssessment(osAssessmentInfos);
+
+      const storage = StorageUtil.getOmnistudioAssessmentStorage();
+
+      // Keys for each OmniScript (lowercased concatenation)
+      const keyAaBb = 'aabbenglish'; // Aa + Bb + English (also same as AaB + b + English)
+      const keyAaDollarBbDollar = 'aa$bb$english'; // Aa$ + Bb$ + English
+
+      // Verify osStorage (non-standard data model)
+      // When allVersions=true: first version of each unique original Type/Subtype/Language is stored,
+      // but if a DIFFERENT OmniScript collides on the same key, it replaces and marks as duplicate
+      expect(storage.osStorage.has(keyAaBb)).to.be.true;
+      expect(storage.osStorage.has(keyAaDollarBbDollar)).to.be.true;
+
+      const storedAaBb = storage.osStorage.get(keyAaBb);
+      const storedAaDollarBbDollar = storage.osStorage.get(keyAaDollarBbDollar);
+
+      // Check key collision: AaB/b/English replaces Aa/Bb/English at key 'aabbenglish'
+      // Last entry wins with isDuplicate=true
+      expect(storedAaBb.originalType).to.equal('AaB');
+      expect(storedAaBb.originalSubtype).to.equal('b');
+      expect(storedAaBb.originalLanguage).to.equal('English');
+      expect(storedAaBb.type).to.equal('AaB');
+      expect(storedAaBb.subtype).to.equal('b');
+      expect(storedAaBb.language).to.equal('English');
+      expect(storedAaBb.isDuplicate).to.be.true; // Marked as duplicate due to collision
+      expect(storedAaBb.migrationSuccess).to.be.true;
+
+      // Check Aa$/Bb$/English (first version stored)
+      expect(storedAaDollarBbDollar.originalType).to.equal('Aa$');
+      expect(storedAaDollarBbDollar.originalSubtype).to.equal('Bb$');
+      expect(storedAaDollarBbDollar.originalLanguage).to.equal('English');
+      expect(storedAaDollarBbDollar.isDuplicate).to.be.false;
+      expect(storedAaDollarBbDollar.migrationSuccess).to.be.false;
+      expect(storedAaDollarBbDollar.error).to.be.an('array').that.is.not.empty;
+
+      // Verify osStandardStorage (standard data model)
+      // Should have all versions of each OmniScript
+      const standardKeyAaBbV1 = JSON.stringify({ type: 'Aa', subtype: 'Bb', language: 'English' });
+      const standardKeyAaDollarV1 = JSON.stringify({ type: 'Aa$', subtype: 'Bb$', language: 'English' });
+      const standardKeyAaBbV2 = JSON.stringify({ type: 'AaB', subtype: 'b', language: 'English' });
+
+      expect(storage.osStandardStorage.has(standardKeyAaBbV1)).to.be.true;
+      expect(storage.osStandardStorage.has(standardKeyAaDollarV1)).to.be.true;
+      expect(storage.osStandardStorage.has(standardKeyAaBbV2)).to.be.true;
+
+      // Verify standard storage entries
+      const standardAaBb = storage.osStandardStorage.get(standardKeyAaBbV1);
+      expect(standardAaBb.originalType).to.equal('Aa');
+      expect(standardAaBb.originalSubtype).to.equal('Bb');
+      expect(standardAaBb.originalLanguage).to.equal('English');
+      expect(standardAaBb.isDuplicate).to.be.false;
+      expect(standardAaBb.migrationSuccess).to.be.true;
+
+      const standardAaDollar = storage.osStandardStorage.get(standardKeyAaDollarV1);
+      expect(standardAaDollar.originalType).to.equal('Aa$');
+      expect(standardAaDollar.originalSubtype).to.equal('Bb$');
+      expect(standardAaDollar.originalLanguage).to.equal('English');
+      expect(standardAaDollar.isDuplicate).to.be.false;
+      expect(standardAaDollar.migrationSuccess).to.be.false;
+
+      const standardAaBb2 = storage.osStandardStorage.get(standardKeyAaBbV2);
+      expect(standardAaBb2.originalType).to.equal('AaB');
+      expect(standardAaBb2.originalSubtype).to.equal('b');
+      expect(standardAaBb2.originalLanguage).to.equal('English');
+      expect(standardAaBb2.isDuplicate).to.be.false;
+      expect(standardAaBb2.migrationSuccess).to.be.true;
+    });
   });
 });

--- a/test/utils/flexipage/flexiPageTransformer.test.ts
+++ b/test/utils/flexipage/flexiPageTransformer.test.ts
@@ -50,7 +50,18 @@ describe('transformFlexipageBundle', () => {
     // Mock StorageUtil
     const mockStorage = {
       osStorage: new Map([
-        ['subtype', { type: 'OSForCustomLWC', subtype: 'OSForCustomLWC', language: 'English', isDuplicate: false }],
+        [
+          'subtype',
+          {
+            type: 'OSForCustomLWC',
+            originalType: 'OSForCustomLWC',
+            subtype: 'OSForCustomLWC',
+            originalSubtype: 'OSForCustomLWC',
+            language: 'English',
+            originalLanguage: 'English',
+            isDuplicate: false,
+          },
+        ],
       ]),
       osStandardStorage: new Map(),
       fcStorage: new Map(),
@@ -111,7 +122,18 @@ describe('transformFlexipageBundle', () => {
     // Mock StorageUtil
     const mockStorage = {
       osStorage: new Map([
-        ['subtype', { type: 'OSForCustomLWC', subtype: 'OSForCustomLWC', language: 'English', isDuplicate: false }],
+        [
+          'subtype',
+          {
+            type: 'OSForCustomLWC',
+            originalType: 'OSForCustomLWC',
+            subtype: 'OSForCustomLWC',
+            originalSubtype: 'OSForCustomLWC',
+            language: 'English',
+            originalLanguage: 'English',
+            isDuplicate: false,
+          },
+        ],
       ]),
       osStandardStorage: new Map(),
       fcStorage: new Map(),
@@ -137,9 +159,42 @@ describe('transformFlexipageBundle', () => {
     // Mock StorageUtil
     const mockStorage = {
       osStorage: new Map([
-        ['subtype1', { type: 'OSForCustomLWC', subtype: 'OSForCustomLWC', language: 'English', isDuplicate: false }],
-        ['subtype2', { type: 'OSForCustomLWC', subtype: 'OSForCustomLWC', language: 'English', isDuplicate: false }],
-        ['subtype3', { type: 'OSForCustomLWC', subtype: 'OSForCustomLWC', language: 'English', isDuplicate: false }],
+        [
+          'subtype1',
+          {
+            type: 'OSForCustomLWC',
+            originalType: 'OSForCustomLWC',
+            subtype: 'OSForCustomLWC',
+            originalSubtype: 'OSForCustomLWC',
+            language: 'English',
+            originalLanguage: 'English',
+            isDuplicate: false,
+          },
+        ],
+        [
+          'subtype2',
+          {
+            type: 'OSForCustomLWC',
+            originalType: 'OSForCustomLWC',
+            subtype: 'OSForCustomLWC',
+            originalSubtype: 'OSForCustomLWC',
+            language: 'English',
+            originalLanguage: 'English',
+            isDuplicate: false,
+          },
+        ],
+        [
+          'subtype3',
+          {
+            type: 'OSForCustomLWC',
+            originalType: 'OSForCustomLWC',
+            subtype: 'OSForCustomLWC',
+            originalSubtype: 'OSForCustomLWC',
+            language: 'English',
+            originalLanguage: 'English',
+            isDuplicate: false,
+          },
+        ],
       ]),
       osStandardStorage: new Map(),
       fcStorage: new Map(),
@@ -171,9 +226,9 @@ describe('transformFlexipageBundle', () => {
       osStorage: new Map(),
       osStandardStorage: new Map(),
       fcStorage: new Map([
-        ['card1', { name: 'Card1', isDuplicate: false }],
-        ['card2', { name: 'Card2', isDuplicate: false }],
-        ['card3', { name: 'Card3', isDuplicate: false }],
+        ['card1', { name: 'Card1', originalName: 'Card1', isDuplicate: false }],
+        ['card2', { name: 'Card2', originalName: 'Card2', isDuplicate: false }],
+        ['card3', { name: 'Card3', originalName: 'Card3', isDuplicate: false }],
       ]),
     };
     sandbox.stub(StorageUtil, 'getOmnistudioMigrationStorage').returns(mockStorage);
@@ -207,13 +262,35 @@ describe('transformFlexipageBundle', () => {
     // Mock StorageUtil
     const mockStorage = {
       osStorage: new Map([
-        ['subtype1', { type: 'OSForCustomLWC', subtype: 'OSForCustomLWC', language: 'English', isDuplicate: false }],
-        ['subtype2', { type: 'OSForCustomLWC', subtype: 'OSForCustomLWC', language: 'English', isDuplicate: false }],
+        [
+          'subtype1',
+          {
+            type: 'OSForCustomLWC',
+            originalType: 'OSForCustomLWC',
+            subtype: 'OSForCustomLWC',
+            originalSubtype: 'OSForCustomLWC',
+            language: 'English',
+            originalLanguage: 'English',
+            isDuplicate: false,
+          },
+        ],
+        [
+          'subtype2',
+          {
+            type: 'OSForCustomLWC',
+            originalType: 'OSForCustomLWC',
+            subtype: 'OSForCustomLWC',
+            originalSubtype: 'OSForCustomLWC',
+            language: 'English',
+            originalLanguage: 'English',
+            isDuplicate: false,
+          },
+        ],
       ]),
       osStandardStorage: new Map(),
       fcStorage: new Map([
-        ['card1', { name: 'Card1', isDuplicate: false }],
-        ['card2', { name: 'Card2', isDuplicate: false }],
+        ['card1', { name: 'Card1', originalName: 'Card1', isDuplicate: false }],
+        ['card2', { name: 'Card2', originalName: 'Card2', isDuplicate: false }],
       ]),
     };
     sandbox.stub(StorageUtil, 'getOmnistudioMigrationStorage').returns(mockStorage);
@@ -247,13 +324,35 @@ describe('transformFlexipageBundle', () => {
     // Mock StorageUtil
     const mockStorage = {
       osStorage: new Map([
-        ['subtype1', { type: 'OSForCustomLWC', subtype: 'OSForCustomLWC', language: 'English', isDuplicate: false }],
-        ['subtype2', { type: 'OSForCustomLWC', subtype: 'OSForCustomLWC', language: 'English', isDuplicate: false }],
+        [
+          'subtype1',
+          {
+            type: 'OSForCustomLWC',
+            originalType: 'OSForCustomLWC',
+            subtype: 'OSForCustomLWC',
+            originalSubtype: 'OSForCustomLWC',
+            language: 'English',
+            originalLanguage: 'English',
+            isDuplicate: false,
+          },
+        ],
+        [
+          'subtype2',
+          {
+            type: 'OSForCustomLWC',
+            originalType: 'OSForCustomLWC',
+            subtype: 'OSForCustomLWC',
+            originalSubtype: 'OSForCustomLWC',
+            language: 'English',
+            originalLanguage: 'English',
+            isDuplicate: false,
+          },
+        ],
       ]),
       osStandardStorage: new Map(),
       fcStorage: new Map([
-        ['card1', { name: 'Card1', isDuplicate: false }],
-        ['card2', { name: 'Card2', isDuplicate: false }],
+        ['card1', { name: 'Card1', originalName: 'Card1', isDuplicate: false }],
+        ['card2', { name: 'Card2', originalName: 'Card2', isDuplicate: false }],
       ]),
     };
     sandbox.stub(StorageUtil, 'getOmnistudioMigrationStorage').returns(mockStorage);
@@ -299,8 +398,30 @@ describe('transformFlexipageBundle', () => {
     // Mock StorageUtil
     const mockStorage = {
       osStorage: new Map([
-        ['mixedcase', { type: 'OSForCustomLWC', subtype: 'OSForCustomLWC', language: 'English', isDuplicate: false }],
-        ['lowercase', { type: 'OSForCustomLWC', subtype: 'OSForCustomLWC', language: 'English', isDuplicate: false }],
+        [
+          'mixedcase',
+          {
+            type: 'OSForCustomLWC',
+            originalType: 'OSForCustomLWC',
+            subtype: 'OSForCustomLWC',
+            originalSubtype: 'OSForCustomLWC',
+            language: 'English',
+            originalLanguage: 'English',
+            isDuplicate: false,
+          },
+        ],
+        [
+          'lowercase',
+          {
+            type: 'OSForCustomLWC',
+            originalType: 'OSForCustomLWC',
+            subtype: 'OSForCustomLWC',
+            originalSubtype: 'OSForCustomLWC',
+            language: 'English',
+            originalLanguage: 'English',
+            isDuplicate: false,
+          },
+        ],
       ]),
       osStandardStorage: new Map(),
       fcStorage: new Map(),
@@ -330,8 +451,8 @@ describe('transformFlexipageBundle', () => {
       osStorage: new Map(),
       osStandardStorage: new Map(),
       fcStorage: new Map([
-        ['mixedcase', { name: 'MixedCaseCard', isDuplicate: false }],
-        ['lowercase', { name: 'lowercasecard', isDuplicate: false }],
+        ['mixedcase', { name: 'MixedCaseCard', originalName: 'MixedCaseCard', isDuplicate: false }],
+        ['lowercase', { name: 'lowercasecard', originalName: 'lowercasecard', isDuplicate: false }],
       ]),
     };
     sandbox.stub(StorageUtil, 'getOmnistudioMigrationStorage').returns(mockStorage);
@@ -361,7 +482,18 @@ describe('transformFlexipageBundle', () => {
     // Mock StorageUtil for assess mode
     const mockStorage = {
       osStorage: new Map([
-        ['mixedcase', { type: 'OSForCustomLWC', subtype: 'OSForCustomLWC', language: 'English', isDuplicate: false }],
+        [
+          'mixedcase',
+          {
+            type: 'OSForCustomLWC',
+            originalType: 'OSForCustomLWC',
+            subtype: 'OSForCustomLWC',
+            originalSubtype: 'OSForCustomLWC',
+            language: 'English',
+            originalLanguage: 'English',
+            isDuplicate: false,
+          },
+        ],
       ]),
       osStandardStorage: new Map(),
       fcStorage: new Map(),
@@ -383,7 +515,7 @@ describe('transformFlexipageBundle', () => {
     const mockStorage = {
       osStorage: new Map(),
       osStandardStorage: new Map(),
-      fcStorage: new Map([['mixedcase', { name: 'MixedCaseCard', isDuplicate: false }]]),
+      fcStorage: new Map([['mixedcase', { name: 'MixedCaseCard', originalName: 'MixedCaseCard', isDuplicate: false }]]),
     };
     sandbox.stub(StorageUtil, 'getOmnistudioAssessmentStorage').returns(mockStorage);
 
@@ -428,7 +560,15 @@ describe('transformFlexipageBundle', () => {
         osStandardStorage: new Map([
           [
             JSON.stringify({ type: 'TestType', subtype: 'TestSubtype', language: 'English' }),
-            { type: 'UpdatedType', subtype: 'UpdatedSubtype', language: 'Spanish', isDuplicate: false },
+            {
+              type: 'UpdatedType',
+              originalType: 'UpdatedType',
+              subtype: 'UpdatedSubtype',
+              originalSubtype: 'UpdatedSubtype',
+              language: 'Spanish',
+              originalLanguage: 'Spanish',
+              isDuplicate: false,
+            },
           ],
         ]),
         fcStorage: new Map(),
@@ -466,7 +606,9 @@ describe('transformFlexipageBundle', () => {
       const mockStorage = {
         osStorage: new Map(),
         osStandardStorage: new Map(),
-        fcStorage: new Map([['testflexcard', { name: 'UpdatedFlexCard', isDuplicate: false }]]),
+        fcStorage: new Map([
+          ['testflexcard', { name: 'UpdatedFlexCard', originalName: 'TestFlexCard', isDuplicate: false }],
+        ]),
       };
       sandbox.stub(StorageUtil, 'getOmnistudioMigrationStorage').returns(mockStorage);
 

--- a/test/utils/storageUtil.test.ts
+++ b/test/utils/storageUtil.test.ts
@@ -83,11 +83,15 @@ describe('StorageUtil', () => {
         type: 'TestType',
         subtype: 'TestSubtype',
         language: 'English',
+        originalType: 'TestType',
+        originalSubtype: 'TestSubtype',
+        originalLanguage: 'English',
         isDuplicate: false,
         migrationSuccess: true,
       };
       const fcData: FlexcardStorage = {
         name: 'TestFlexcard',
+        originalName: 'TestFlexcard',
         isDuplicate: false,
         migrationSuccess: true,
       };
@@ -146,6 +150,9 @@ describe('StorageUtil', () => {
         type: 'ModifiedType',
         subtype: 'ModifiedSubtype',
         language: 'Spanish',
+        originalType: 'ModifiedType',
+        originalSubtype: 'ModifiedSubtype',
+        originalLanguage: 'Spanish',
         isDuplicate: true,
         migrationSuccess: false,
         error: ['Migration failed'],
@@ -165,6 +172,7 @@ describe('StorageUtil', () => {
       const storage = StorageUtil.getOmnistudioMigrationStorage();
       const fcData: FlexcardStorage = {
         name: 'ModifiedFlexcard',
+        originalName: 'ModifiedFlexcard',
         isDuplicate: true,
         migrationSuccess: false,
         error: ['Flexcard migration failed'],
@@ -186,20 +194,28 @@ describe('StorageUtil', () => {
         type: 'Type1',
         subtype: 'Subtype1',
         language: 'English',
+        originalType: 'Type1',
+        originalSubtype: 'Subtype1',
+        originalLanguage: 'English',
         isDuplicate: false,
       };
       const osData2: OmniScriptStorage = {
         type: 'Type2',
         subtype: 'Subtype2',
         language: 'French',
+        originalType: 'Type2',
+        originalSubtype: 'Subtype2',
+        originalLanguage: 'French',
         isDuplicate: true,
       };
       const fcData1: FlexcardStorage = {
         name: 'Flexcard1',
+        originalName: 'Flexcard1',
         isDuplicate: false,
       };
       const fcData2: FlexcardStorage = {
         name: 'Flexcard2',
+        originalName: 'Flexcard2',
         isDuplicate: true,
       };
 
@@ -227,6 +243,9 @@ describe('StorageUtil', () => {
         type: 'DeleteType',
         subtype: 'DeleteSubtype',
         language: 'German',
+        originalType: 'DeleteType',
+        originalSubtype: 'DeleteSubtype',
+        originalLanguage: 'German',
         isDuplicate: false,
       };
 
@@ -252,6 +271,9 @@ describe('StorageUtil', () => {
         type: 'TestType',
         subtype: 'TestSubtype',
         language: 'English',
+        originalType: 'TestType',
+        originalSubtype: 'TestSubtype',
+        originalLanguage: 'English',
         isDuplicate: false,
       });
 


### PR DESCRIPTION
### What does this PR do?
Refactored and updated storage util for all versions omniscripts and flexcards
Earlier if allVersions were run for migration and omniscript/flexcard had mutliple versions, the isDuplicate flag was set to true.
isDuplicate should be set to true if the omniscript has the same type, subtype, language combination.
Changes to correct the way isDuplicate is set when allVersions are run for migration.


### What issues does this PR fix or reference?


