### PR TITLE
feat: @W-19835630: Prudential Post Migration issues

### DIFF
--- a/messages/assess.json
+++ b/messages/assess.json
@@ -92,6 +92,7 @@
   "methodCallBundleNameUpdated": "Method call bundle name will be updated in %s for the %s class and %s method.",
   "cardNameChangeMessage": "The Flexcard name will be changed from %s to %s to adhere to the API naming standards.",
   "authordNameChangeMessage": "The Flexcard author name will be changed from %s to %s to adhere to the naming rules: %s",
+  "cardLWCNameChangeMessage": "The Flexcard generated LWC name will be changed from %s to %s to align with Flexcard name change.",
   "omniScriptNameChangeMessage": "The Omniscript reference name %s will be changed to %s during migration.",
   "dataRaptorNameChangeMessage": "The Data Mapper name will be changed from %s to %s during migration.",
   "integrationProcedureNameChangeMessage": "The Integration Procedure %s will be renamed to %s during migration.",

--- a/messages/migrate.json
+++ b/messages/migrate.json
@@ -283,5 +283,6 @@
   "deploymentNonRetryableError": "Deployment failed with non-retryable error: %s. Please review and fix the issue manually",
   "deploymentTriggeredSuccessfully": "Please monitor your Deployment: %s using deployment status page in Org",
   "omniscriptPackageDeploymentFailedReturnedFalse": "Omniscript package deployment failed - deployment returned false. This may be due to missing package, permissions, or deployment timeout.",
-  "omniscriptPackageDeploymentFailedWithMessage": "Omniscript package deployment failed: %s"
+  "omniscriptPackageDeploymentFailedWithMessage": "Omniscript package deployment failed: %s",
+  "customLWCFlexCardReferenceUpdated": "Updated Custom LWC FlexCard reference: %s -> cf%s"
 }

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -1244,7 +1244,7 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
         const customLwcName = component.property.customlwcname;
 
         // Check if this is a FlexCard reference (starts with "cf" prefix)
-        if (component.property.customlwcname?.startsWith('cf')) {
+        if (customLwcName?.startsWith('cf')) {
           // Remove "cf" prefix to get the original FlexCard name
           const originalFlexCardName = customLwcName.substring(2);
 

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -1244,24 +1244,17 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
         const customLwcName = component.property.customlwcname;
 
         // Check if this is a FlexCard reference (starts with "cf" prefix)
-        if (customLwcName.startsWith('cf')) {
+        if (component.property.customlwcname?.startsWith('cf')) {
           // Remove "cf" prefix to get the original FlexCard name
           const originalFlexCardName = customLwcName.substring(2);
 
           // Look up the cleaned name from registry
-          if (this.nameRegistry.hasFlexCardMapping(originalFlexCardName)) {
-            const cleanedFlexCardName = this.nameRegistry.getFlexCardCleanedName(originalFlexCardName);
-            // Update the customlwcname with the cleaned FlexCard name
-            component.property.customlwcname = `cf${cleanedFlexCardName}`;
-            Logger.logVerbose(`Updated customLwc FlexCard reference: ${customLwcName} -> cf${cleanedFlexCardName}`);
-          } else {
-            // No registry mapping - use fallback cleaning
-            Logger.logVerbose(
-              `\n${this.messages.getMessage('componentMappingNotFound', ['Flexcard', originalFlexCardName])}`
-            );
-            const cleanedFlexCardName = this.cleanName(originalFlexCardName);
-            component.property.customlwcname = `cf${cleanedFlexCardName}`;
-          }
+          const cleanedFlexCardName = this.nameRegistry.getFlexCardCleanedName(originalFlexCardName);
+          // Update the customlwcname with the cleaned FlexCard name
+          component.property.customlwcname = `cf${cleanedFlexCardName}`;
+          Logger.logVerbose(
+            this.messages.getMessage('customLWCFlexCardReferenceUpdated', [customLwcName, cleanedFlexCardName])
+          );
         }
         // Note: Other custom LWC names (not starting with "cf") typically don't need cleaning
       }

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -532,6 +532,28 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
         const customLwcName = component.property.customlwcname;
         Logger.info(`Custom LWC name: ${customLwcName}`);
 
+        // Check if this is a FlexCard reference (starts with "cf" prefix)
+        if (customLwcName.startsWith('cf')) {
+          // Remove "cf" prefix to get the original FlexCard name
+          const originalFlexCardName = customLwcName.substring(2);
+
+          // Check if the FlexCard name will change and add warning
+          const cleanedFlexCardName = this.cleanName(originalFlexCardName);
+          if (originalFlexCardName !== cleanedFlexCardName) {
+            flexCardAssessmentInfo.warnings.push(
+              this.messages.getMessage('cardLWCNameChangeMessage', [originalFlexCardName, cleanedFlexCardName])
+            );
+            flexCardAssessmentInfo.migrationStatus = getUpdatedAssessmentStatus(
+              flexCardAssessmentInfo.migrationStatus as
+                | 'Warnings'
+                | 'Needs manual intervention'
+                | 'Ready for migration'
+                | 'Failed',
+              'Warnings'
+            );
+          }
+        }
+        // Regular custom LWC (and FlexCard reference)
         // Avoid duplicates
         if (!flexCardAssessmentInfo.dependenciesLWC.includes(customLwcName)) {
           flexCardAssessmentInfo.dependenciesLWC.push(customLwcName);
@@ -1216,9 +1238,33 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
       }
     }
 
-    // Handle Custom LWC components (no cleaning needed typically)
+    // Handle Custom LWC components - special case for FlexCard references
     if (component.element === 'customLwc' && component.property) {
-      // Note: Custom LWC names typically don't need cleaning
+      if (component.property.customlwcname) {
+        const customLwcName = component.property.customlwcname;
+
+        // Check if this is a FlexCard reference (starts with "cf" prefix)
+        if (customLwcName.startsWith('cf')) {
+          // Remove "cf" prefix to get the original FlexCard name
+          const originalFlexCardName = customLwcName.substring(2);
+
+          // Look up the cleaned name from registry
+          if (this.nameRegistry.hasFlexCardMapping(originalFlexCardName)) {
+            const cleanedFlexCardName = this.nameRegistry.getFlexCardCleanedName(originalFlexCardName);
+            // Update the customlwcname with the cleaned FlexCard name
+            component.property.customlwcname = `cf${cleanedFlexCardName}`;
+            Logger.logVerbose(`Updated customLwc FlexCard reference: ${customLwcName} -> cf${cleanedFlexCardName}`);
+          } else {
+            // No registry mapping - use fallback cleaning
+            Logger.logVerbose(
+              `\n${this.messages.getMessage('componentMappingNotFound', ['Flexcard', originalFlexCardName])}`
+            );
+            const cleanedFlexCardName = this.cleanName(originalFlexCardName);
+            component.property.customlwcname = `cf${cleanedFlexCardName}`;
+          }
+        }
+        // Note: Other custom LWC names (not starting with "cf") typically don't need cleaning
+      }
     }
 
     // Handle standard component actions (like assessment)

--- a/src/migration/related/LwcMigration.ts
+++ b/src/migration/related/LwcMigration.ts
@@ -82,7 +82,6 @@ export class LwcMigration extends BaseRelatedObjectMigration {
           dir !== Constants.LWC &&
           !dir.endsWith('MultiLanguage') &&
           !dir.endsWith('English') &&
-          !dir.includes('_') &&
           !dir.startsWith('cf') &&
           !dir.startsWith('Omniscript') &&
           !dir.includes('Util') &&

--- a/src/utils/formula/FormulaUtil.ts
+++ b/src/utils/formula/FormulaUtil.ts
@@ -10,17 +10,22 @@ function getReplacedformulaString(
   formulaExpression: string,
   formulaName: string,
   className: string,
-  methodName: string
+  methodName: string,
+  namespacePrefix?: string
 ): string {
   const regExStr = new RegExp('\\b' + formulaName + '\\b', 'g');
   const startIndex = formulaExpression.search(regExStr);
   const startParanthIndex = startIndex + formulaName.length;
   const endParanthIndex = getClosingIndexOfParantheses(formulaExpression, startParanthIndex);
+
+  // If namespace prefix exists, prepend it to the class name
+  const qualifiedClassName = namespacePrefix ? `${namespacePrefix}.${className}` : className;
+
   const newFormulaExpression =
     'FUNCTION(' +
-    `'${className}'` +
+    `"${qualifiedClassName}"` +
     ',' +
-    `'${methodName}'` +
+    `"${methodName}"` +
     ',' +
     formulaExpression.substring(startParanthIndex + 1, endParanthIndex) +
     ')';
@@ -95,11 +100,15 @@ export function getReplacedString(
     const numberOfOccurances: number = match !== null ? match.length : 0;
     if (numberOfOccurances > 0) {
       for (var count: number = 1; count <= numberOfOccurances; count++) {
+        // Get the namespace from the function definition metadata
+        const functionNamespace = functionDefMd['NamespacePrefix'];
+
         formulaSyntax = getReplacedformulaString(
           formulaSyntax,
           functionDefMd['DeveloperName'],
           functionDefMd[namespacePrefix + 'ClassName__c'],
-          functionDefMd[namespacePrefix + 'MethodName__c']
+          functionDefMd[namespacePrefix + 'MethodName__c'],
+          functionNamespace
         );
       }
     }

--- a/src/utils/lwcparser/jsParser/JavaScriptParser.ts
+++ b/src/utils/lwcparser/jsParser/JavaScriptParser.ts
@@ -10,6 +10,8 @@ import { FileConstant } from '../fileutils/FileConstant';
 import { Logger } from '../../logger';
 
 const DEFAULT_NAMESPACE = 'c';
+const PUBSUB_MODULE = 'pubsub';
+const OMNISTUDIO_PUBSUB_MODULE = 'lightning/omnistudioPubsub';
 
 export class JavaScriptParser {
   // Function to replace strings in import declarations and write back to file
@@ -43,9 +45,14 @@ export class JavaScriptParser {
 
         // Check if the import source contains the old substring
         if (importSource.includes(oldSource + '/')) {
-          // Replace the old substring with the new substring
-          const updatedSource = importSource.replace(oldSource, DEFAULT_NAMESPACE);
-          replacements.push({ original: importSource, updated: updatedSource });
+          // Special handling for pubsub module - replace with lightning/omnistudioPubsub
+          if (importSource.endsWith('/' + PUBSUB_MODULE)) {
+            replacements.push({ original: importSource, updated: OMNISTUDIO_PUBSUB_MODULE });
+          } else {
+            // Replace the old substring with the new substring (default namespace 'c')
+            const updatedSource = importSource.replace(oldSource, DEFAULT_NAMESPACE);
+            replacements.push({ original: importSource, updated: updatedSource });
+          }
         }
       },
     });

--- a/test/utils/formula/formulaUtil.test.ts
+++ b/test/utils/formula/formulaUtil.test.ts
@@ -11,7 +11,7 @@ describe('FormulaUtilTest', () => {
     const inputString = "TESTMETHODFIRST('hello','bye')";
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     const result = getReplacedString(namespacePrefix, inputString, mockedFunctionDefinitionMetadata);
-    const expectedResult = "FUNCTION('testClassFirst','testMethodFirst','hello','bye')";
+    const expectedResult = 'FUNCTION("testClassFirst","testMethodFirst",\'hello\',\'bye\')';
 
     expect(result).to.be.equal(expectedResult);
   });
@@ -24,7 +24,7 @@ describe('FormulaUtilTest', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     const result = getReplacedString(namespacePrefix, inputString, mockedFunctionDefinitionMetadata);
     const expectedResult =
-      "FUNCTION('testClassFirst','testMethodFirst','hello',FUNCTION('testClass','testMethod','bye'))";
+      'FUNCTION("testClassFirst","testMethodFirst",\'hello\',FUNCTION("testClass","testMethod",\'bye\'))';
 
     expect(result).to.be.equal(expectedResult);
   });
@@ -37,7 +37,30 @@ describe('FormulaUtilTest', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     const result = getReplacedString(namespacePrefix, inputString, mockedFunctionDefinitionMetadata);
     const expectedResult =
-      "FUNCTION('testClassFirst','testMethodFirst','hello',FUNCTION('testClass','testMethod',FUNCTION('testClassFirst','testMethodFirst','bye','check')))";
+      'FUNCTION("testClassFirst","testMethodFirst",\'hello\',FUNCTION("testClass","testMethod",FUNCTION("testClassFirst","testMethodFirst",\'bye\',\'check\')))';
+    expect(result).to.be.equal(expectedResult);
+  });
+
+  it('should include namespace prefix in class name when function has namespace', () => {
+    const namespacePrefix = 'test_namespace__';
+    const mockedFunctionDefinitionMetadata = getMockedFunctionMetadataWithNamespace();
+    populateRegexForFunctionMetadata(mockedFunctionDefinitionMetadata);
+    const inputString = "NAMESPACEDMETHOD('param1')";
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    const result = getReplacedString(namespacePrefix, inputString, mockedFunctionDefinitionMetadata);
+    const expectedResult = 'FUNCTION("pkg_namespace.NamespacedClass","namespacedMethod",\'param1\')';
+    expect(result).to.be.equal(expectedResult);
+  });
+
+  it('should handle functions with and without namespace in same formula', () => {
+    const namespacePrefix = 'test_namespace__';
+    const mockedFunctionDefinitionMetadata = getMixedFunctionMetadata();
+    populateRegexForFunctionMetadata(mockedFunctionDefinitionMetadata);
+    const inputString = "TESTMETHOD('hello',NAMESPACEDMETHOD('world'))";
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    const result = getReplacedString(namespacePrefix, inputString, mockedFunctionDefinitionMetadata);
+    const expectedResult =
+      'FUNCTION("testClass","testMethod",\'hello\',FUNCTION("pkg_namespace.NamespacedClass","namespacedMethod",\'world\'))';
     expect(result).to.be.equal(expectedResult);
   });
 });
@@ -48,21 +71,53 @@ function getMockedAllFunctionMetadata(): AnyJson[] {
       DeveloperName: 'TESTMETHOD',
       test_namespace__ClassName__c: 'testClass',
       test_namespace__MethodName__c: 'testMethod',
+      NamespacePrefix: null,
     },
     {
       DeveloperName: 'TESTMETHODFIRST',
       test_namespace__ClassName__c: 'testClassFirst',
       test_namespace__MethodName__c: 'testMethodFirst',
+      NamespacePrefix: null,
     },
     {
       DeveloperName: 'TESTMETHODSECOND',
       test_namespace__ClassName__c: 'testClassSecond',
       test_namespace__MethodName__c: 'testMethodSecond',
+      NamespacePrefix: null,
     },
     {
       DeveloperName: 'TESTMETHODTHIRD',
       test_namespace__ClassName__c: 'testClassThird',
       test_namespace__MethodName__c: 'testMethodThird',
+      NamespacePrefix: null,
+    },
+  ];
+}
+
+function getMockedFunctionMetadataWithNamespace(): AnyJson[] {
+  return [
+    {
+      DeveloperName: 'NAMESPACEDMETHOD',
+      test_namespace__ClassName__c: 'NamespacedClass',
+      test_namespace__MethodName__c: 'namespacedMethod',
+      NamespacePrefix: 'pkg_namespace',
+    },
+  ];
+}
+
+function getMixedFunctionMetadata(): AnyJson[] {
+  return [
+    {
+      DeveloperName: 'TESTMETHOD',
+      test_namespace__ClassName__c: 'testClass',
+      test_namespace__MethodName__c: 'testMethod',
+      NamespacePrefix: null,
+    },
+    {
+      DeveloperName: 'NAMESPACEDMETHOD',
+      test_namespace__ClassName__c: 'NamespacedClass',
+      test_namespace__MethodName__c: 'namespacedMethod',
+      NamespacePrefix: 'pkg_namespace',
     },
   ];
 }


### PR DESCRIPTION
Changes:
- Handle Flexcard custom LWC name change with assess/migrate
- Flexcard pubsub doesn't have the `c` impl so moved to `lightning` implementation
- Formula parser to handle custom functoins with namespace and className/methodName
- Added the test cases for all cases

### What does this PR do?

### What issues does this PR fix or reference?
