### PR TITLE
@W-20470731 Contd Execution should stop during assessment if metadata config records are present in an org where OmniStudio Metadata is disabled and API response to handle obejct and array.

### DIFF
--- a/src/commands/omnistudio/migration/assess.ts
+++ b/src/commands/omnistudio/migration/assess.ts
@@ -139,7 +139,7 @@ export default class Assess extends SfCommand<AssessmentInfo> {
 
     const namespace = orgs.packageDetails.namespace;
     let projectPath = '';
-    const preMigrate: PreMigrate = new PreMigrate(namespace, conn, this.logger, messages, this.ux);
+    const preMigrate: PreMigrate = new PreMigrate(namespace, conn, logger, messages, ux);
     const userActionMessages: string[] = [];
 
     // Handle all versions prerequisite for standard data model

--- a/src/utils/OmnistudioSettingsPrefManager.ts
+++ b/src/utils/OmnistudioSettingsPrefManager.ts
@@ -11,7 +11,7 @@ export class OmnistudioSettingsPrefManager {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
       const result = (await (this.connection.metadata.read as any)('OmniStudioSettings', ['OmniStudio'])) as unknown;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const metadata = result as MetadataInfo;
+      const metadata = (Array.isArray(result) ? result[0] : result) as MetadataInfo;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       return metadata?.enableOmniGlobalAutoNumberPref === 'true' || false;
     } catch (error) {
@@ -48,7 +48,7 @@ export class OmnistudioSettingsPrefManager {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
       const result = (await (this.connection.metadata.read as any)('OmniStudioSettings', ['OmniStudio'])) as unknown;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const metadata = result as MetadataInfo;
+      const metadata = (Array.isArray(result) ? result[0] : result) as MetadataInfo;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       return metadata?.enableStandardOmniStudioRuntime === 'true' || false;
     } catch (error) {
@@ -86,7 +86,7 @@ export class OmnistudioSettingsPrefManager {
       const result = (await (this.connection.metadata.read as any)('OmniStudioSettings', ['OmniStudio'])) as unknown;
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const metadata = result as MetadataInfo;
+      const metadata = (Array.isArray(result) ? result[0] : result) as MetadataInfo;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       return metadata?.enableOmniStudioMetadata === 'true' || false;
     } catch (error) {

--- a/src/utils/orgPreferences.ts
+++ b/src/utils/orgPreferences.ts
@@ -59,8 +59,8 @@ export class OrgPreferences {
         'OmniStudioDrVersionOrgPreference',
       ]);
       Logger.captureVerboseData('DR version response', result);
-      const metadata = result as MetadataInfo;
-      return metadata.enableOmniStudioDrVersion === 'true';
+      const metadata = (Array.isArray(result) ? result[0] : result) as MetadataInfo;
+      return metadata?.enableOmniStudioDrVersion === 'true';
     } catch (error) {
       throw new Error(`Failed to read DR version: ${error instanceof Error ? error.message : String(error)}`);
     }

--- a/test/commands/omnistudio/migration/assess-flags-validation.test.ts
+++ b/test/commands/omnistudio/migration/assess-flags-validation.test.ts
@@ -32,7 +32,9 @@ describe('Assess command flags validation', () => {
     }
 
     expect(loggerErrorStub.calledOnce).to.be.true;
-    expect(loggerErrorStub.firstCall.args[0]).to.equal('Related flags are not supported with only flag.');
+    expect(loggerErrorStub.firstCall.args[0]).to.equal(
+      'Related objects [ex: Apex, lwc, expsites and flexipages] are not supported with only flag.'
+    );
     expect(processExitStub.calledWith(1)).to.be.true;
   });
 

--- a/test/commands/omnistudio/migration/migrate-flags-validation.test.ts
+++ b/test/commands/omnistudio/migration/migrate-flags-validation.test.ts
@@ -32,7 +32,9 @@ describe('Migrate command flags validation', () => {
     }
 
     expect(loggerErrorStub.calledOnce).to.be.true;
-    expect(loggerErrorStub.firstCall.args[0]).to.equal('Related flags are not supported with only flag.');
+    expect(loggerErrorStub.firstCall.args[0]).to.equal(
+      'Related objects [ex: Apex, lwc, expsites and flexipages] are not supported with only flag.'
+    );
     expect(processExitStub.calledWith(1)).to.be.true;
   });
 


### PR DESCRIPTION
### What does this PR do?
Fixing the function signature which was resulting in build failures.
The API calls to handle the return of both object or array data type.

### What issues does this PR fix or reference?
