### PR TITLE
@W-19747584 - Custom CSS Scanning and Assessment for Flexcard and Omniscript

### DIFF
--- a/messages/assess.json
+++ b/messages/assess.json
@@ -188,6 +188,7 @@
   "nameMappingUndefined": "Undefined name mapping found",
   "experienceSiteException": "We’ve encountered an exception while processing Experience Cloud sites.",
   "reservedKeysFoundInPropertySet": "The Integration Procedure output uses these reserved keys in the transformation property fields: %s",
+  "customCssStylesheetNamespaceWarning": "Custom CSS stylesheet '%s' has namespace references, styles may break after migration.",
   "dataMapperMigrationFailed": "DataMapper migration failed for: %s",
   "dataMapperNameStartsWithNumber": "DataMapper name '%s' starts with a number which causes migration issues. Proposed new name: %s",
   "integrationProcedureTypeEmptyAfterCleaning": "Integration Procedure Type '%s' becomes empty after name cleaning. Please provide a valid Type value.",

--- a/messages/assess.json
+++ b/messages/assess.json
@@ -189,6 +189,7 @@
   "experienceSiteException": "We’ve encountered an exception while processing Experience Cloud sites.",
   "reservedKeysFoundInPropertySet": "The Integration Procedure output uses these reserved keys in the transformation property fields: %s",
   "customCssStylesheetNamespaceWarning": "Custom CSS stylesheet '%s' has namespace references, styles may break after migration.",
+  "customCssInlineNamespaceWarning": "Custom CSS has namespace references, styles may break after migration.",
   "dataMapperMigrationFailed": "DataMapper migration failed for: %s",
   "dataMapperNameStartsWithNumber": "DataMapper name '%s' starts with a number which causes migration issues. Proposed new name: %s",
   "integrationProcedureTypeEmptyAfterCleaning": "Integration Procedure Type '%s' becomes empty after name cleaning. Please provide a valid Type value.",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "cli-progress": "^3.12.0",
     "diff": "^5.1.0",
     "jsdom": "^25.0.0",
+    "jszip": "^3.10.1",
     "lodash.chunk": "^4.2.0",
     "open": "^8.4.2",
     "shelljs": "^0.8.5",

--- a/src/migration/CustomCssRegistry.ts
+++ b/src/migration/CustomCssRegistry.ts
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* eslint-disable */
+import { Connection, Messages } from '@salesforce/core';
+import { QueryTools } from '../utils/query';
+import { Logger } from '../utils/logger';
+
+/**
+ * Outcome of scanning a single Static Resource for namespace references.
+ *  - `notFound`    — no record with this Name exists in the org
+ *  - `unsupported` — body was unreadable or non-text & non-zip
+ *  - `clean`       — fetched, scanned, no namespace match
+ *  - `dirty`       — fetched, scanned, namespace match found
+ */
+export type CustomCssScanVerdict = 'notFound' | 'unsupported' | 'clean' | 'dirty';
+
+/**
+ * Result of scanning the four-key `stylesheet` object embedded in an OmniScript's
+ * (or FlexCard's) PropertySetConfig. Returns the names of stylesheets whose
+ * StaticResource bodies still reference the org's managed-package namespace.
+ *
+ * Callers use `dirtyStylesheets` to push warnings; the array preserves insertion
+ * order so messages reflect the variant order checked (lightning, newport, …).
+ */
+export interface CustomCssStylesheetScanResult {
+  dirtyStylesheets: string[];
+}
+
+/**
+ * Centralised, process-wide cache & scanner for Static Resources referenced as
+ * "Custom Lightning / Newport Stylesheet File Name" in OmniScript / FlexCard
+ * PropertySetConfig.
+ *
+ * Why a registry (vs a per-tool field):
+ *  - The same StaticResource is frequently shared across many OmniScripts and
+ *    (in future) FlexCards. We don't want to re-query / re-download it per tool.
+ *  - OmniScript and Integration Procedure are two separate
+ *    `OmniScriptMigrationTool` instances in the assess flow — without the
+ *    registry, their caches would be siloed.
+ *  - Future component types (FlexCard, etc.) can plug in by calling
+ *    `scanResource()` directly without re-implementing the fetch/zip/scan logic.
+ *
+ * Lifetime: a single assessment run. Tools call `init(connection, namespace,
+ * messages)` once at construction time; subsequent inits are idempotent (the
+ * first one wins, and a `reset()` is exposed for tests / re-entrant runs).
+ */
+export class CustomCssRegistry {
+  private static instance: CustomCssRegistry;
+
+  private cache: Map<string, CustomCssScanVerdict> = new Map();
+  private connection?: Connection;
+  private namespace?: string;
+  private messages?: Messages<string>;
+
+  /** Variant keys present on `propertySetConfig.stylesheet` for OmniScript. */
+  private static readonly OMNISCRIPT_STYLESHEET_VARIANTS: ReadonlyArray<
+    'lightning' | 'newport' | 'lightningRtl' | 'newportRtl'
+  > = ['lightning', 'newport', 'lightningRtl', 'newportRtl'];
+
+  public static getInstance(): CustomCssRegistry {
+    if (!CustomCssRegistry.instance) {
+      CustomCssRegistry.instance = new CustomCssRegistry();
+    }
+    return CustomCssRegistry.instance;
+  }
+
+  /**
+   * Configure the registry. Safe to call multiple times — the first non-empty
+   * configuration wins, so the order in which tools initialise doesn't matter.
+   */
+  public init(connection: Connection, namespace: string, messages: Messages<string>): void {
+    if (!this.connection) this.connection = connection;
+    if (!this.namespace && namespace) this.namespace = namespace;
+    if (!this.messages) this.messages = messages;
+  }
+
+  /** Clears cache + configuration. Intended for tests / re-entrant assess runs. */
+  public reset(): void {
+    this.cache.clear();
+    this.connection = undefined;
+    this.namespace = undefined;
+    this.messages = undefined;
+  }
+
+  /** Whether namespace scanning is meaningful in the current run. */
+  public isEnabled(): boolean {
+    return Boolean(this.connection && this.namespace);
+  }
+
+  /**
+   * Scan the four OmniScript stylesheet variants
+   * (`lightning`, `newport`, `lightningRtl`, `newportRtl`) on a parsed
+   * `propertySetConfig.stylesheet` object and return any that still reference
+   * the configured namespace inside their CSS body.
+   *
+   * Returns an empty result when scanning is disabled (no namespace configured)
+   * or when the stylesheet object is missing / malformed.
+   */
+  public async scanOmniScriptStylesheets(stylesheet: unknown): Promise<CustomCssStylesheetScanResult> {
+    const result: CustomCssStylesheetScanResult = { dirtyStylesheets: [] };
+
+    if (!this.isEnabled()) return result;
+    if (!stylesheet || typeof stylesheet !== 'object') return result;
+
+    const sheet = stylesheet as Record<string, unknown>;
+    for (const variant of CustomCssRegistry.OMNISCRIPT_STYLESHEET_VARIANTS) {
+      const raw = sheet[variant];
+      const resourceName = (raw == null ? '' : String(raw)).trim();
+      if (!resourceName) continue;
+
+      const verdict = await this.scanResource(resourceName);
+      if (verdict === 'dirty') {
+        result.dirtyStylesheets.push(resourceName);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Build the customer-facing warning message for a dirty stylesheet. Centralised
+   * here so both OmniScript and (future) FlexCard collectors phrase warnings
+   * identically. Returns `null` if the registry has no message bundle yet.
+   */
+  public buildNamespaceWarning(resourceName: string): string | null {
+    if (!this.messages || !this.namespace) return null;
+    return this.messages.getMessage('customCssStylesheetNamespaceWarning', [resourceName]);
+  }
+
+  /**
+   * Look up a Static Resource by Name, fetch its body (handling text and zip
+   * bodies), and report whether the configured namespace appears anywhere in
+   * its CSS. Cached by Name for the lifetime of the registry.
+   *
+   * Public so future component types (FlexCard, …) can reuse the cache directly
+   * without going through `scanOmniScriptStylesheets`.
+   */
+  public async scanResource(resourceName: string): Promise<CustomCssScanVerdict> {
+    if (!resourceName) return 'notFound';
+
+    const cached = this.cache.get(resourceName);
+    if (cached) return cached;
+
+    if (!this.connection || !this.namespace) {
+      // Registry was queried before init() — treat as unsupported but don't cache;
+      // a later init() must still get a chance to scan.
+      return 'unsupported';
+    }
+
+    // 1. Look up the record. StaticResource is a standard sObject — no namespace prefix.
+    const filters = new Map<string, any>([['Name', resourceName]]);
+    const rows = (await QueryTools.query(
+      this.connection,
+      'StaticResource',
+      ['Id', 'Name', 'ContentType', 'BodyLength'],
+      filters
+    )) as any[];
+
+    if (!rows || rows.length === 0) {
+      this.cache.set(resourceName, 'notFound');
+      return 'notFound';
+    }
+
+    const sr = rows[0];
+    const contentType: string = (sr.ContentType || '').toLowerCase();
+    const apiVersion = this.connection.getApiVersion();
+    const url = `/services/data/v${apiVersion}/sobjects/StaticResource/${sr.Id}/Body`;
+    const containsNamespace = (text: string): boolean => text.includes(this.namespace as string);
+
+    try {
+      // Plain-text resource (text/css, text/plain, application/json, or unknown).
+      if (contentType.startsWith('text/') || contentType === 'application/json' || contentType === '') {
+        const raw = await this.connection.request<any>({ method: 'GET', url });
+        const cssText: string = Buffer.isBuffer(raw) ? raw.toString('utf8') : String(raw ?? '');
+        const verdict: CustomCssScanVerdict = containsNamespace(cssText) ? 'dirty' : 'clean';
+        this.cache.set(resourceName, verdict);
+        return verdict;
+      }
+
+      // Zip archive — scan every .css entry.
+      if (contentType === 'application/zip' || contentType === 'application/x-zip-compressed') {
+        const raw = await this.connection.request<any>({ method: 'GET', url });
+        const buf: Buffer = Buffer.isBuffer(raw) ? raw : Buffer.from(raw, 'binary');
+        // Lazy-require so jszip only loads when a zipped resource is actually encountered.
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const JSZip = require('jszip');
+        const zip = await JSZip.loadAsync(buf);
+        let dirty = false;
+        const entries: any[] = Object.values(zip.files);
+        for (const file of entries) {
+          if (file.dir) continue;
+          if (!/\.css$/i.test(file.name)) continue;
+          const cssText: string = await file.async('string');
+          if (containsNamespace(cssText)) {
+            dirty = true;
+            break;
+          }
+        }
+        const verdict: CustomCssScanVerdict = dirty ? 'dirty' : 'clean';
+        this.cache.set(resourceName, verdict);
+        return verdict;
+      }
+
+      // Anything else — flag unsupported but don't warn (avoids false positives).
+      this.cache.set(resourceName, 'unsupported');
+      return 'unsupported';
+    } catch (err) {
+      Logger.error(`Failed to fetch/scan StaticResource '${resourceName}': ${(err as Error).message}`);
+      this.cache.set(resourceName, 'unsupported');
+      return 'unsupported';
+    }
+  }
+}

--- a/src/migration/CustomCssRegistry.ts
+++ b/src/migration/CustomCssRegistry.ts
@@ -5,30 +5,42 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-/* eslint-disable */
 import { Connection, Messages } from '@salesforce/core';
+import JSZip from 'jszip';
 import { QueryTools } from '../utils/query';
 import { Logger } from '../utils/logger';
 
 /**
  * Outcome of scanning a single Static Resource for namespace references.
- *  - `notFound`    — no record with this Name exists in the org
- *  - `unsupported` — body was unreadable or non-text & non-zip
- *  - `clean`       — fetched, scanned, no namespace match
- *  - `dirty`       — fetched, scanned, namespace match found
+ * - `notFound`        — no record with this Name exists in the org
+ * - `unsupported`     — body was unreadable or non-text & non-zip
+ * - `noNamespaceRef`  — fetched, scanned, no namespace match
+ * - `namespaceFound`  — fetched, scanned, namespace match found
  */
-export type CustomCssScanVerdict = 'notFound' | 'unsupported' | 'clean' | 'dirty';
+export type CustomCssScanVerdict = 'notFound' | 'unsupported' | 'noNamespaceRef' | 'namespaceFound';
 
 /**
  * Result of scanning the four-key `stylesheet` object embedded in an OmniScript's
  * (or FlexCard's) PropertySetConfig. Returns the names of stylesheets whose
  * StaticResource bodies still reference the org's managed-package namespace.
  *
- * Callers use `dirtyStylesheets` to push warnings; the array preserves insertion
- * order so messages reflect the variant order checked (lightning, newport, …).
+ * Names are deduplicated, so a single resource referenced from multiple variant
+ * keys (e.g. both `lightning` and `newport`) appears only once.
  */
 export interface CustomCssStylesheetScanResult {
-  dirtyStylesheets: string[];
+  stylesheetsWithNamespaceRefs: string[];
+}
+
+/**
+ * Subset of fields read off a `StaticResource` SOQL row during a scan.
+ * `Body` is intentionally absent — that field is not queryable via SOQL and
+ * must be fetched through the REST blob endpoint.
+ */
+interface StaticResourceRecord {
+  Id: string;
+  Name: string;
+  ContentType: string;
+  BodyLength: number;
 }
 
 /**
@@ -36,14 +48,13 @@ export interface CustomCssStylesheetScanResult {
  * "Custom Lightning / Newport Stylesheet File Name" in OmniScript / FlexCard
  * PropertySetConfig.
  *
- * Why a registry (vs a per-tool field):
- *  - The same StaticResource is frequently shared across many OmniScripts and
- *    (in future) FlexCards. We don't want to re-query / re-download it per tool.
- *  - OmniScript and Integration Procedure are two separate
- *    `OmniScriptMigrationTool` instances in the assess flow — without the
- *    registry, their caches would be siloed.
- *  - Future component types (FlexCard, etc.) can plug in by calling
- *    `scanResource()` directly without re-implementing the fetch/zip/scan logic.
+ * Why a registry (vs a per-tool field): the same StaticResource is frequently
+ * shared across many OmniScripts and FlexCards. We don't want to re-query or
+ * re-download it per tool. OmniScript and Integration Procedure are two
+ * separate `OmniScriptMigrationTool` instances in the assess flow — without
+ * the registry, their caches would be siloed. Future component types can plug
+ * in by calling `scanResource()` directly without re-implementing the
+ * fetch/zip/scan logic.
  *
  * Lifetime: a single assessment run. Tools call `init(connection, namespace,
  * messages)` once at construction time; subsequent inits are idempotent (the
@@ -52,15 +63,15 @@ export interface CustomCssStylesheetScanResult {
 export class CustomCssRegistry {
   private static instance: CustomCssRegistry;
 
-  private cache: Map<string, CustomCssScanVerdict> = new Map();
-  private connection?: Connection;
-  private namespace?: string;
-  private messages?: Messages<string>;
-
   /** Variant keys present on `propertySetConfig.stylesheet` for OmniScript. */
   private static readonly OMNISCRIPT_STYLESHEET_VARIANTS: ReadonlyArray<
     'lightning' | 'newport' | 'lightningRtl' | 'newportRtl'
   > = ['lightning', 'newport', 'lightningRtl', 'newportRtl'];
+
+  private cache: Map<string, CustomCssScanVerdict> = new Map();
+  private connection?: Connection;
+  private namespace?: string;
+  private messages?: Messages<string>;
 
   public static getInstance(): CustomCssRegistry {
     if (!CustomCssRegistry.instance) {
@@ -96,36 +107,39 @@ export class CustomCssRegistry {
    * Scan the four OmniScript stylesheet variants
    * (`lightning`, `newport`, `lightningRtl`, `newportRtl`) on a parsed
    * `propertySetConfig.stylesheet` object and return any that still reference
-   * the configured namespace inside their CSS body.
+   * the configured namespace inside their CSS body. Duplicate resource names
+   * (the same StaticResource referenced from multiple variants) are collapsed.
    *
    * Returns an empty result when scanning is disabled (no namespace configured)
    * or when the stylesheet object is missing / malformed.
    */
   public async scanOmniScriptStylesheets(stylesheet: unknown): Promise<CustomCssStylesheetScanResult> {
-    const result: CustomCssStylesheetScanResult = { dirtyStylesheets: [] };
+    const result: CustomCssStylesheetScanResult = { stylesheetsWithNamespaceRefs: [] };
 
     if (!this.isEnabled()) return result;
     if (!stylesheet || typeof stylesheet !== 'object') return result;
 
     const sheet = stylesheet as Record<string, unknown>;
+    const flagged = new Set<string>();
     for (const variant of CustomCssRegistry.OMNISCRIPT_STYLESHEET_VARIANTS) {
       const raw = sheet[variant];
       const resourceName = (raw == null ? '' : String(raw)).trim();
       if (!resourceName) continue;
 
       const verdict = await this.scanResource(resourceName);
-      if (verdict === 'dirty') {
-        result.dirtyStylesheets.push(resourceName);
+      if (verdict === 'namespaceFound') {
+        flagged.add(resourceName);
       }
     }
+    result.stylesheetsWithNamespaceRefs = [...flagged];
     return result;
   }
 
   /**
-   * Build the customer-facing warning message for a dirty StaticResource-based
-   * stylesheet. Centralised here so both OmniScript and FlexCard collectors
-   * phrase warnings identically. Returns `null` if the registry has no message
-   * bundle yet.
+   * Build the customer-facing warning message for a StaticResource-backed
+   * stylesheet that contains namespace references. Centralised here so both
+   * OmniScript and FlexCard collectors phrase warnings identically. Returns
+   * `null` if the registry has no message bundle yet.
    */
   public buildNamespaceWarning(resourceName: string): string | null {
     if (!this.messages || !this.namespace) return null;
@@ -151,7 +165,7 @@ export class CustomCssRegistry {
   public containsNamespaceInText(text: unknown): boolean {
     if (!this.isEnabled()) return false;
     if (typeof text !== 'string' || text.length === 0) return false;
-    return text.includes(this.namespace as string);
+    return text.includes(this.namespace);
   }
 
   /**
@@ -174,67 +188,82 @@ export class CustomCssRegistry {
       return 'unsupported';
     }
 
-    // 1. Look up the record. StaticResource is a standard sObject — no namespace prefix.
+    const sr = await this.lookupStaticResource(resourceName);
+    if (!sr) {
+      this.cache.set(resourceName, 'notFound');
+      return 'notFound';
+    }
+
+    const verdict = await this.scanStaticResourceBody(sr);
+    this.cache.set(resourceName, verdict);
+    return verdict;
+  }
+
+  /** SOQL lookup of a StaticResource by Name. Returns undefined when not found. */
+  private async lookupStaticResource(resourceName: string): Promise<StaticResourceRecord | undefined> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const filters = new Map<string, any>([['Name', resourceName]]);
     const rows = (await QueryTools.query(
       this.connection,
       'StaticResource',
       ['Id', 'Name', 'ContentType', 'BodyLength'],
       filters
-    )) as any[];
+    )) as StaticResourceRecord[];
+    return rows && rows.length > 0 ? rows[0] : undefined;
+  }
 
-    if (!rows || rows.length === 0) {
-      this.cache.set(resourceName, 'notFound');
-      return 'notFound';
-    }
-
-    const sr = rows[0];
+  /**
+   * Fetch the StaticResource body and dispatch to the appropriate scanner.
+   * Errors are logged and folded into the `unsupported` verdict so a single
+   * broken resource doesn't poison the rest of the assessment run.
+   */
+  private async scanStaticResourceBody(sr: StaticResourceRecord): Promise<CustomCssScanVerdict> {
     const contentType: string = (sr.ContentType || '').toLowerCase();
     const apiVersion = this.connection.getApiVersion();
     const url = `/services/data/v${apiVersion}/sobjects/StaticResource/${sr.Id}/Body`;
-    const containsNamespace = (text: string): boolean => text.includes(this.namespace as string);
 
     try {
-      // Plain-text resource (text/css, text/plain, application/json, or unknown).
-      if (contentType.startsWith('text/') || contentType === 'application/json' || contentType === '') {
-        const raw = await this.connection.request<any>({ method: 'GET', url });
-        const cssText: string = Buffer.isBuffer(raw) ? raw.toString('utf8') : String(raw ?? '');
-        const verdict: CustomCssScanVerdict = containsNamespace(cssText) ? 'dirty' : 'clean';
-        this.cache.set(resourceName, verdict);
-        return verdict;
+      if (this.isTextContentType(contentType)) {
+        return await this.scanTextBody(url);
       }
-
-      // Zip archive — scan every .css entry.
-      if (contentType === 'application/zip' || contentType === 'application/x-zip-compressed') {
-        const raw = await this.connection.request<any>({ method: 'GET', url });
-        const buf: Buffer = Buffer.isBuffer(raw) ? raw : Buffer.from(raw, 'binary');
-        // Lazy-require so jszip only loads when a zipped resource is actually encountered.
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const JSZip = require('jszip');
-        const zip = await JSZip.loadAsync(buf);
-        let dirty = false;
-        const entries: any[] = Object.values(zip.files);
-        for (const file of entries) {
-          if (file.dir) continue;
-          if (!/\.css$/i.test(file.name)) continue;
-          const cssText: string = await file.async('string');
-          if (containsNamespace(cssText)) {
-            dirty = true;
-            break;
-          }
-        }
-        const verdict: CustomCssScanVerdict = dirty ? 'dirty' : 'clean';
-        this.cache.set(resourceName, verdict);
-        return verdict;
+      if (this.isZipContentType(contentType)) {
+        return await this.scanZipBody(url);
       }
-
-      // Anything else — flag unsupported but don't warn (avoids false positives).
-      this.cache.set(resourceName, 'unsupported');
+      // Unsupported content type — don't false-positive.
       return 'unsupported';
     } catch (err) {
-      Logger.error(`Failed to fetch/scan StaticResource '${resourceName}': ${(err as Error).message}`);
-      this.cache.set(resourceName, 'unsupported');
+      Logger.error(`Failed to fetch/scan StaticResource '${sr.Name}': ${(err as Error).message}`);
       return 'unsupported';
     }
+  }
+
+  private isTextContentType(contentType: string): boolean {
+    return contentType.startsWith('text/') || contentType === 'application/json' || contentType === '';
+  }
+
+  private isZipContentType(contentType: string): boolean {
+    return contentType === 'application/zip' || contentType === 'application/x-zip-compressed';
+  }
+
+  /** Fetch a plain-text body and substring-check for the namespace. */
+  private async scanTextBody(url: string): Promise<CustomCssScanVerdict> {
+    const raw = await this.connection.request<string | Buffer>({ method: 'GET', url });
+    const cssText: string = Buffer.isBuffer(raw) ? raw.toString('utf8') : String(raw ?? '');
+    return cssText.includes(this.namespace) ? 'namespaceFound' : 'noNamespaceRef';
+  }
+
+  /** Fetch a zip body and substring-check the namespace across every .css entry. */
+  private async scanZipBody(url: string): Promise<CustomCssScanVerdict> {
+    const raw = await this.connection.request<string | Buffer>({ method: 'GET', url });
+    const buf: Buffer = Buffer.isBuffer(raw) ? raw : Buffer.from(raw, 'binary');
+    const zip = await JSZip.loadAsync(buf);
+    const entries: JSZip.JSZipObject[] = Object.values(zip.files);
+    for (const file of entries) {
+      if (file.dir) continue;
+      if (!/\.css$/i.test(file.name)) continue;
+      const cssText: string = await file.async('string');
+      if (cssText.includes(this.namespace)) return 'namespaceFound';
+    }
+    return 'noNamespaceRef';
   }
 }

--- a/src/migration/CustomCssRegistry.ts
+++ b/src/migration/CustomCssRegistry.ts
@@ -122,13 +122,36 @@ export class CustomCssRegistry {
   }
 
   /**
-   * Build the customer-facing warning message for a dirty stylesheet. Centralised
-   * here so both OmniScript and (future) FlexCard collectors phrase warnings
-   * identically. Returns `null` if the registry has no message bundle yet.
+   * Build the customer-facing warning message for a dirty StaticResource-based
+   * stylesheet. Centralised here so both OmniScript and FlexCard collectors
+   * phrase warnings identically. Returns `null` if the registry has no message
+   * bundle yet.
    */
   public buildNamespaceWarning(resourceName: string): string | null {
     if (!this.messages || !this.namespace) return null;
     return this.messages.getMessage('customCssStylesheetNamespaceWarning', [resourceName]);
+  }
+
+  /**
+   * Build the customer-facing warning message for inline CSS (e.g. FlexCard's
+   * `Styles__c.customStyles`) that contains namespace references. No
+   * StaticResource is involved, so no resource name is interpolated — the
+   * surrounding row in the assessment report already identifies the component.
+   */
+  public buildInlineCssNamespaceWarning(): string | null {
+    if (!this.messages || !this.namespace) return null;
+    return this.messages.getMessage('customCssInlineNamespaceWarning');
+  }
+
+  /**
+   * Substring-test the configured namespace against an arbitrary CSS string.
+   * Used for FlexCard `Styles__c.customStyles` (raw inline CSS) — no caching
+   * because the input is per-record and not shared.
+   */
+  public containsNamespaceInText(text: unknown): boolean {
+    if (!this.isEnabled()) return false;
+    if (typeof text !== 'string' || text.length === 0) return false;
+    return text.includes(this.namespace as string);
   }
 
   /**

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -4,6 +4,7 @@ import CardMappings from '../mappings/VlocityCard';
 import { DebugTimer, QueryTools, SortDirection } from '../utils';
 import { NetUtils } from '../utils/net';
 import { BaseMigrationTool } from './base';
+import { CustomCssRegistry } from './CustomCssRegistry';
 import {
   InvalidEntityTypeError,
   MigrationResult,
@@ -42,6 +43,7 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
   ) {
     super(namespace, connection, logger, messages, ux);
     this.allVersions = allVersions;
+    CustomCssRegistry.getInstance().init(connection, namespace, messages);
   }
 
   getName(): string {
@@ -304,6 +306,11 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
     flexCardAssessmentInfo.migrationStatus = assessmentStatus;
     this.updateDependencies(flexCard, flexCardAssessmentInfo);
 
+    // Scan custom CSS (both StaticResource-backed and inline) for managed-package
+    // namespace references. The helper updates `migrationStatus` itself via
+    // `getUpdatedAssessmentStatus`, so it never downgrades a stricter status.
+    await this.collectStylesheetNamespaceDependencies(flexCard, flexCardAssessmentInfo);
+
     // Deduplicate all dependency arrays to ensure no duplicates
     flexCardAssessmentInfo.dependenciesIP = [...new Set(flexCardAssessmentInfo.dependenciesIP)];
     flexCardAssessmentInfo.dependenciesDR = [...new Set(flexCardAssessmentInfo.dependenciesDR)];
@@ -315,6 +322,92 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
     ];
 
     return flexCardAssessmentInfo;
+  }
+
+  /**
+   * Scan a FlexCard for two distinct kinds of namespace-bound custom CSS:
+   *
+   *  1. **StaticResource-backed stylesheet** — `Definition__c.customStyleSheet`
+   *     stores the *Name* of a Static Resource. We look it up, fetch its body,
+   *     and substring-check for the org's managed-package namespace. Same flow
+   *     and same warning message as the OmniScript implementation; resource
+   *     scans are cached by name in {@link CustomCssRegistry}, so a stylesheet
+   *     shared between OmniScripts and FlexCards is only fetched once per run.
+   *
+   *  2. **Inline CSS** — `Styles__c.customStyles` stores raw CSS text. We
+   *     substring-check the namespace directly against that string. No
+   *     SOQL/REST traffic and no caching (the CSS is per-FlexCard and not
+   *     shared across records).
+   *
+   * Both checks emit a warning into `flexCardAssessmentInfo.warnings` and bump
+   * `migrationStatus` to 'Warnings' (using `getUpdatedAssessmentStatus` so a
+   * stricter status set elsewhere is preserved).
+   */
+  private async collectStylesheetNamespaceDependencies(
+    flexCard: AnyJson,
+    flexCardAssessmentInfo: FlexCardAssessmentInfo
+  ): Promise<void> {
+    const registry = CustomCssRegistry.getInstance();
+    if (!registry.isEnabled()) {
+      return;
+    }
+
+    // ---- 1. Definition__c.customStyleSheet (StaticResource name) ----
+    const definitionRaw = flexCard[this.getFieldKey('Definition__c')];
+    if (definitionRaw) {
+      let definition: any;
+      try {
+        definition = JSON.parse(definitionRaw);
+      } catch (ex) {
+        Logger.error(`Failed to parse Definition__c for stylesheet scan: ${flexCard['Name']}`);
+        definition = null;
+      }
+      const resourceName = (definition?.customStyleSheet || '').toString().trim();
+      if (resourceName) {
+        const verdict = await registry.scanResource(resourceName);
+        if (verdict === 'dirty') {
+          const message = registry.buildNamespaceWarning(resourceName);
+          if (message) {
+            flexCardAssessmentInfo.warnings.push(message);
+            flexCardAssessmentInfo.migrationStatus = getUpdatedAssessmentStatus(
+              flexCardAssessmentInfo.migrationStatus as
+                | 'Warnings'
+                | 'Needs manual intervention'
+                | 'Ready for migration'
+                | 'Failed',
+              'Warnings'
+            );
+          }
+        }
+      }
+    }
+
+    // ---- 2. Styles__c.customStyles (raw inline CSS) ----
+    const stylesRaw = flexCard[this.getFieldKey('Styles__c')];
+    if (stylesRaw) {
+      let styles: any;
+      try {
+        styles = JSON.parse(stylesRaw);
+      } catch (ex) {
+        Logger.error(`Failed to parse Styles__c for stylesheet scan: ${flexCard['Name']}`);
+        styles = null;
+      }
+      const inlineCss = styles?.customStyles;
+      if (registry.containsNamespaceInText(inlineCss)) {
+        const message = registry.buildInlineCssNamespaceWarning();
+        if (message) {
+          flexCardAssessmentInfo.warnings.push(message);
+          flexCardAssessmentInfo.migrationStatus = getUpdatedAssessmentStatus(
+            flexCardAssessmentInfo.migrationStatus as
+              | 'Warnings'
+              | 'Needs manual intervention'
+              | 'Ready for migration'
+              | 'Failed',
+            'Warnings'
+          );
+        }
+      }
+    }
   }
 
   private updateDependencies(flexCard, flexCardAssessmentInfo): void {

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -365,7 +365,7 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
       const resourceName = (definition?.customStyleSheet || '').toString().trim();
       if (resourceName) {
         const verdict = await registry.scanResource(resourceName);
-        if (verdict === 'dirty') {
+        if (verdict === 'namespaceFound') {
           const message = registry.buildNamespaceWarning(resourceName);
           if (message) {
             flexCardAssessmentInfo.warnings.push(message);

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -2700,8 +2700,8 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
       return;
     }
 
-    const { dirtyStylesheets } = await registry.scanOmniScriptStylesheets(propertySetConfig?.stylesheet);
-    for (const resourceName of dirtyStylesheets) {
+    const { stylesheetsWithNamespaceRefs } = await registry.scanOmniScriptStylesheets(propertySetConfig?.stylesheet);
+    for (const resourceName of stylesheetsWithNamespaceRefs) {
       const message = registry.buildNamespaceWarning(resourceName);
       if (message) {
         warnings.push(message);

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -14,6 +14,7 @@ import {
   SortDirection,
 } from '../utils';
 import { BaseMigrationTool, ComponentType } from './base';
+import { CustomCssRegistry } from './CustomCssRegistry';
 import {
   InvalidEntityTypeError,
   MigrationResult,
@@ -79,6 +80,9 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     super(namespace, connection, logger, messages, ux);
     this.exportType = exportType;
     this.allVersions = allVersions;
+    // Configure the shared Custom CSS registry. Idempotent — safe to call from
+    // both the OS and IP tool instances within a single assess run.
+    CustomCssRegistry.getInstance().init(connection, namespace, messages);
   }
 
   getName(
@@ -686,6 +690,15 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
         assessmentStatus = 'Needs manual intervention';
       }
     }
+
+    // Scan custom Lightning/Newport stylesheets for managed-package namespace references.
+    // Runs after all other warnings/status logic so the precedence guard correctly preserves
+    // any prior 'Needs manual intervention' status set above.
+    await this.collectStylesheetNamespaceDependencies(omniscript, warnings, () => {
+      if (assessmentStatus === 'Ready for migration') {
+        assessmentStatus = 'Warnings';
+      }
+    });
 
     // Deduplicate all dependency arrays to ensure no duplicates
     // For Remote Actions and LWCs, deduplicate by name property
@@ -2647,6 +2660,54 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
         }
       });
     });
+  }
+
+  /**
+   * Reads the OmniScript's custom Lightning/Newport stylesheet references from
+   * PropertySetConfig and warns if the referenced StaticResource's CSS body
+   * still contains the org's managed-package namespace string. Such references
+   * won't resolve after migration and would silently break styling.
+   *
+   * Heavy lifting (StaticResource lookup, body fetch, zip extraction, scan,
+   * cache) lives in {@link CustomCssRegistry} so the same cache can later be
+   * shared with FlexCard assessment without re-querying the same resources.
+   *
+   * @param omniscript     The OmniScript/IP record being assessed.
+   * @param warnings       Warnings array on the in-progress OSAssessmentInfo (mutated).
+   * @param escalateStatus Callback that promotes assessmentStatus to 'Warnings'
+   *                       (without downgrading 'Needs manual intervention').
+   */
+  private async collectStylesheetNamespaceDependencies(
+    omniscript: AnyJson,
+    warnings: string[],
+    escalateStatus: () => void
+  ): Promise<void> {
+    const registry = CustomCssRegistry.getInstance();
+    if (!registry.isEnabled()) {
+      return;
+    }
+
+    const propertySetConfigStr = omniscript[this.getFieldKey('PropertySet__c')];
+    if (!propertySetConfigStr) {
+      return;
+    }
+
+    let propertySetConfig: any;
+    try {
+      propertySetConfig = JSON.parse(propertySetConfigStr);
+    } catch (ex) {
+      Logger.error(`Failed to parse PropertySetConfig for stylesheet scan: ${omniscript['Name']}`);
+      return;
+    }
+
+    const { dirtyStylesheets } = await registry.scanOmniScriptStylesheets(propertySetConfig?.stylesheet);
+    for (const resourceName of dirtyStylesheets) {
+      const message = registry.buildNamespaceWarning(resourceName);
+      if (message) {
+        warnings.push(message);
+        escalateStatus();
+      }
+    }
   }
 
   private getElementFieldKey(fieldName: string): string {

--- a/test/migration/CustomCssRegistry.test.ts
+++ b/test/migration/CustomCssRegistry.test.ts
@@ -1,0 +1,352 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, camelcase, comma-dangle */
+import { expect } from 'chai';
+import { CustomCssRegistry } from '../../src/migration/CustomCssRegistry';
+// jszip ships CommonJS — require() exposes the constructor at the top level.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const JSZip = require('jszip');
+
+/**
+ * Builds a minimal `connection` double with `query` + `request` stubs that the
+ * registry calls. `query` is invoked by `QueryTools.query()` and must return
+ * `{ totalSize, records }`. `request` is the REST blob fetch.
+ */
+function buildMockConnection(opts: {
+  records?: any[];
+  body?: any;
+  apiVersion?: string;
+  onQuery?: (sql: string) => void;
+  onRequest?: (req: any) => void;
+}) {
+  return {
+    query: (sql: string) => {
+      if (opts.onQuery) opts.onQuery(sql);
+      const records = opts.records ?? [];
+      return Promise.resolve({ totalSize: records.length, records });
+    },
+    request: (req: any) => {
+      if (opts.onRequest) opts.onRequest(req);
+      return Promise.resolve(opts.body ?? '');
+    },
+    getApiVersion: () => opts.apiVersion ?? '60.0',
+  };
+}
+
+function buildMockMessages(): any {
+  return {
+    getMessage: (key: string, args?: string[]) => {
+      if (key === 'customCssStylesheetNamespaceWarning') {
+        return `Custom CSS stylesheet '${args?.[0]}' has namespace references, styles may break after migration.`;
+      }
+      if (key === 'customCssInlineNamespaceWarning') {
+        return 'Custom inline CSS has namespace references, styles may break after migration.';
+      }
+      return `Mock message: ${key}`;
+    },
+  };
+}
+
+describe('CustomCssRegistry', () => {
+  let registry: CustomCssRegistry;
+
+  beforeEach(() => {
+    registry = CustomCssRegistry.getInstance();
+    registry.reset();
+  });
+
+  describe('init() / isEnabled() / reset()', () => {
+    it('isEnabled returns false before init', () => {
+      expect(registry.isEnabled()).to.equal(false);
+    });
+
+    it('isEnabled returns true once connection and namespace are configured', () => {
+      const conn = buildMockConnection({});
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+      expect(registry.isEnabled()).to.equal(true);
+    });
+
+    it('isEnabled stays false when namespace is empty even if connection is set', () => {
+      const conn = buildMockConnection({});
+      registry.init(conn as any, '', buildMockMessages());
+      expect(registry.isEnabled()).to.equal(false);
+    });
+
+    it('init is idempotent — second init does not overwrite the first', () => {
+      const conn1 = buildMockConnection({});
+      const conn2 = buildMockConnection({});
+      registry.init(conn1 as any, 'vlocity_cmt', buildMockMessages());
+      registry.init(conn2 as any, 'somethingElse', buildMockMessages());
+      // First connection wins; second init is a no-op
+      expect((registry as any).connection).to.equal(conn1);
+      expect((registry as any).namespace).to.equal('vlocity_cmt');
+    });
+
+    it('reset clears connection, namespace, messages, and cache', async () => {
+      const conn = buildMockConnection({
+        records: [{ Id: '081xx', Name: 'foo', ContentType: 'text/css', BodyLength: 10 }],
+        body: 'body { color: red; }',
+      });
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+      await registry.scanResource('foo');
+      expect((registry as any).cache.size).to.equal(1);
+
+      registry.reset();
+      expect(registry.isEnabled()).to.equal(false);
+      expect((registry as any).cache.size).to.equal(0);
+    });
+  });
+
+  describe('scanResource() — text/css body', () => {
+    it('returns dirty when body contains the namespace', async () => {
+      const conn = buildMockConnection({
+        records: [{ Id: '081xx', Name: 'foo', ContentType: 'text/css', BodyLength: 30 }],
+        body: '.vlocity_cmt-card-title { color: red; }',
+      });
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+      const verdict = await registry.scanResource('foo');
+      expect(verdict).to.equal('dirty');
+    });
+
+    it('returns clean when body does not contain the namespace', async () => {
+      const conn = buildMockConnection({
+        records: [{ Id: '081xx', Name: 'foo', ContentType: 'text/css', BodyLength: 25 }],
+        body: '.something-else { color: red; }',
+      });
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+      const verdict = await registry.scanResource('foo');
+      expect(verdict).to.equal('clean');
+    });
+
+    it('returns notFound when SOQL returns zero rows', async () => {
+      const conn = buildMockConnection({ records: [] });
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+      const verdict = await registry.scanResource('missing_resource');
+      expect(verdict).to.equal('notFound');
+    });
+
+    it('handles a Buffer response by decoding to utf8', async () => {
+      const buf = Buffer.from('.vlocity_cmt-foo {}', 'utf8');
+      const conn = buildMockConnection({
+        records: [{ Id: '081xx', Name: 'foo', ContentType: 'text/css', BodyLength: buf.length }],
+        body: buf,
+      });
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+      const verdict = await registry.scanResource('foo');
+      expect(verdict).to.equal('dirty');
+    });
+  });
+
+  describe('scanResource() — caching', () => {
+    it('does not re-query or re-fetch the same resource on the second call', async () => {
+      let queryCount = 0;
+      let requestCount = 0;
+      const conn = buildMockConnection({
+        records: [{ Id: '081xx', Name: 'foo', ContentType: 'text/css', BodyLength: 5 }],
+        body: 'body{}',
+        onQuery: () => queryCount++,
+        onRequest: () => requestCount++,
+      });
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+
+      const v1 = await registry.scanResource('foo');
+      const v2 = await registry.scanResource('foo');
+
+      expect(v1).to.equal('clean');
+      expect(v2).to.equal('clean');
+      expect(queryCount).to.equal(1);
+      expect(requestCount).to.equal(1);
+    });
+
+    it('caches notFound verdicts so missing resources are not re-queried', async () => {
+      let queryCount = 0;
+      const conn = buildMockConnection({
+        records: [],
+        onQuery: () => queryCount++,
+      });
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+
+      await registry.scanResource('missing');
+      await registry.scanResource('missing');
+      expect(queryCount).to.equal(1);
+    });
+  });
+
+  describe('scanResource() — application/zip body', () => {
+    it('returns dirty when any .css entry inside the zip contains the namespace', async () => {
+      const zip = new JSZip();
+      zip.file('themes/lightning.css', '.vlocity_cmt-foo { display: none; }');
+      const buf: Buffer = await zip.generateAsync({ type: 'nodebuffer' });
+      const conn = buildMockConnection({
+        records: [{ Id: '081xx', Name: 'bundle', ContentType: 'application/zip', BodyLength: buf.length }],
+        body: buf,
+      });
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+      const verdict = await registry.scanResource('bundle');
+      expect(verdict).to.equal('dirty');
+    });
+
+    it('returns clean when zip has only namespace-free .css entries', async () => {
+      const zip = new JSZip();
+      zip.file('themes/lightning.css', '.foo { color: red; }');
+      zip.file('themes/notes.txt', 'this is not css');
+      const buf: Buffer = await zip.generateAsync({ type: 'nodebuffer' });
+      const conn = buildMockConnection({
+        records: [{ Id: '081xx', Name: 'bundle', ContentType: 'application/zip', BodyLength: buf.length }],
+        body: buf,
+      });
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+      const verdict = await registry.scanResource('bundle');
+      expect(verdict).to.equal('clean');
+    });
+  });
+
+  describe('scanResource() — unsupported and error paths', () => {
+    it('returns unsupported for binary content types', async () => {
+      const conn = buildMockConnection({
+        records: [{ Id: '081xx', Name: 'image', ContentType: 'image/png', BodyLength: 99 }],
+        body: '',
+      });
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+      const verdict = await registry.scanResource('image');
+      expect(verdict).to.equal('unsupported');
+    });
+
+    it('returns unsupported when the body fetch throws', async () => {
+      const conn: any = {
+        query: () =>
+          Promise.resolve({
+            totalSize: 1,
+            records: [{ Id: '081xx', Name: 'foo', ContentType: 'text/css', BodyLength: 10 }],
+          }),
+        request: () => Promise.reject(new Error('network down')),
+        getApiVersion: () => '60.0',
+      };
+      registry.init(conn, 'vlocity_cmt', buildMockMessages());
+      const verdict = await registry.scanResource('foo');
+      expect(verdict).to.equal('unsupported');
+    });
+
+    it('returns notFound for an empty resourceName without contacting the org', async () => {
+      let queryCount = 0;
+      const conn = buildMockConnection({ onQuery: () => queryCount++ });
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+      const verdict = await registry.scanResource('');
+      expect(verdict).to.equal('notFound');
+      expect(queryCount).to.equal(0);
+    });
+
+    it('returns unsupported (and does not query) when called pre-init', async () => {
+      // Registry has been reset() in beforeEach, so it's pre-init here.
+      const verdict = await registry.scanResource('foo');
+      expect(verdict).to.equal('unsupported');
+    });
+  });
+
+  describe('scanOmniScriptStylesheets()', () => {
+    it('returns empty result when registry is not enabled', async () => {
+      const result = await registry.scanOmniScriptStylesheets({ lightning: 'foo', newport: 'bar' });
+      expect(result.dirtyStylesheets).to.deep.equal([]);
+    });
+
+    it('returns empty result when stylesheet object is missing or non-object', async () => {
+      const conn = buildMockConnection({});
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+
+      const r1 = await registry.scanOmniScriptStylesheets(undefined);
+      const r2 = await registry.scanOmniScriptStylesheets(null);
+      const r3 = await registry.scanOmniScriptStylesheets('a string');
+      expect(r1.dirtyStylesheets).to.deep.equal([]);
+      expect(r2.dirtyStylesheets).to.deep.equal([]);
+      expect(r3.dirtyStylesheets).to.deep.equal([]);
+    });
+
+    it('skips empty / falsy variant names', async () => {
+      let queryCount = 0;
+      const conn = buildMockConnection({
+        records: [],
+        onQuery: () => queryCount++,
+      });
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+
+      await registry.scanOmniScriptStylesheets({
+        lightning: '',
+        newport: null,
+        lightningRtl: undefined,
+        newportRtl: '   ', // whitespace-only
+      });
+      expect(queryCount).to.equal(0);
+    });
+
+    it('returns dirty stylesheet names in variant order, deduped via cache', async () => {
+      const conn = buildMockConnection({
+        records: [{ Id: '081xx', Name: 'sharedSheet', ContentType: 'text/css', BodyLength: 30 }],
+        body: '.vlocity_cmt-foo {}',
+      });
+      registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
+
+      // Both variants point at the same resource — cache prevents two SOQLs.
+      let queryCount = 0;
+      (conn as any).query = () => {
+        queryCount++;
+        return Promise.resolve({
+          totalSize: 1,
+          records: [{ Id: '081xx', Name: 'sharedSheet', ContentType: 'text/css', BodyLength: 30 }],
+        });
+      };
+
+      const result = await registry.scanOmniScriptStylesheets({
+        lightning: 'sharedSheet',
+        newport: 'sharedSheet',
+        lightningRtl: '',
+        newportRtl: '',
+      });
+
+      expect(result.dirtyStylesheets).to.deep.equal(['sharedSheet', 'sharedSheet']);
+      expect(queryCount).to.equal(1);
+    });
+  });
+
+  describe('buildNamespaceWarning() / buildInlineCssNamespaceWarning()', () => {
+    it('returns null when not configured', () => {
+      expect(registry.buildNamespaceWarning('foo')).to.equal(null);
+      expect(registry.buildInlineCssNamespaceWarning()).to.equal(null);
+    });
+
+    it('returns the formatted stylesheet warning with the resource name interpolated', () => {
+      registry.init(buildMockConnection({}) as any, 'vlocity_cmt', buildMockMessages());
+      const msg = registry.buildNamespaceWarning('foo');
+      expect(msg).to.include("'foo'");
+      expect(msg).to.include('namespace references');
+    });
+
+    it('returns the inline-CSS warning without interpolating a name', () => {
+      registry.init(buildMockConnection({}) as any, 'vlocity_cmt', buildMockMessages());
+      const msg = registry.buildInlineCssNamespaceWarning();
+      expect(msg).to.include('Custom inline CSS');
+      expect(msg).to.include('namespace references');
+    });
+  });
+
+  describe('containsNamespaceInText()', () => {
+    it('returns false when registry not enabled', () => {
+      expect(registry.containsNamespaceInText('.vlocity_cmt-foo {}')).to.equal(false);
+    });
+
+    it('returns false for non-string / empty input', () => {
+      registry.init(buildMockConnection({}) as any, 'vlocity_cmt', buildMockMessages());
+      expect(registry.containsNamespaceInText(undefined)).to.equal(false);
+      expect(registry.containsNamespaceInText(null)).to.equal(false);
+      expect(registry.containsNamespaceInText(42)).to.equal(false);
+      expect(registry.containsNamespaceInText('')).to.equal(false);
+    });
+
+    it('returns true when text contains the namespace substring', () => {
+      registry.init(buildMockConnection({}) as any, 'vlocity_cmt', buildMockMessages());
+      expect(registry.containsNamespaceInText('.vlocity_cmt-card { display: none; }')).to.equal(true);
+    });
+
+    it('returns false when text does not contain the namespace', () => {
+      registry.init(buildMockConnection({}) as any, 'vlocity_cmt', buildMockMessages());
+      expect(registry.containsNamespaceInText('.foo { color: red; }')).to.equal(false);
+    });
+  });
+});

--- a/test/migration/CustomCssRegistry.test.ts
+++ b/test/migration/CustomCssRegistry.test.ts
@@ -96,24 +96,24 @@ describe('CustomCssRegistry', () => {
   });
 
   describe('scanResource() — text/css body', () => {
-    it('returns dirty when body contains the namespace', async () => {
+    it('returns namespaceFound when body contains the namespace', async () => {
       const conn = buildMockConnection({
         records: [{ Id: '081xx', Name: 'foo', ContentType: 'text/css', BodyLength: 30 }],
         body: '.vlocity_cmt-card-title { color: red; }',
       });
       registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
       const verdict = await registry.scanResource('foo');
-      expect(verdict).to.equal('dirty');
+      expect(verdict).to.equal('namespaceFound');
     });
 
-    it('returns clean when body does not contain the namespace', async () => {
+    it('returns noNamespaceRef when body does not contain the namespace', async () => {
       const conn = buildMockConnection({
         records: [{ Id: '081xx', Name: 'foo', ContentType: 'text/css', BodyLength: 25 }],
         body: '.something-else { color: red; }',
       });
       registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
       const verdict = await registry.scanResource('foo');
-      expect(verdict).to.equal('clean');
+      expect(verdict).to.equal('noNamespaceRef');
     });
 
     it('returns notFound when SOQL returns zero rows', async () => {
@@ -131,7 +131,7 @@ describe('CustomCssRegistry', () => {
       });
       registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
       const verdict = await registry.scanResource('foo');
-      expect(verdict).to.equal('dirty');
+      expect(verdict).to.equal('namespaceFound');
     });
   });
 
@@ -150,8 +150,8 @@ describe('CustomCssRegistry', () => {
       const v1 = await registry.scanResource('foo');
       const v2 = await registry.scanResource('foo');
 
-      expect(v1).to.equal('clean');
-      expect(v2).to.equal('clean');
+      expect(v1).to.equal('noNamespaceRef');
+      expect(v2).to.equal('noNamespaceRef');
       expect(queryCount).to.equal(1);
       expect(requestCount).to.equal(1);
     });
@@ -171,7 +171,7 @@ describe('CustomCssRegistry', () => {
   });
 
   describe('scanResource() — application/zip body', () => {
-    it('returns dirty when any .css entry inside the zip contains the namespace', async () => {
+    it('returns namespaceFound when any .css entry inside the zip contains the namespace', async () => {
       const zip = new JSZip();
       zip.file('themes/lightning.css', '.vlocity_cmt-foo { display: none; }');
       const buf: Buffer = await zip.generateAsync({ type: 'nodebuffer' });
@@ -181,10 +181,10 @@ describe('CustomCssRegistry', () => {
       });
       registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
       const verdict = await registry.scanResource('bundle');
-      expect(verdict).to.equal('dirty');
+      expect(verdict).to.equal('namespaceFound');
     });
 
-    it('returns clean when zip has only namespace-free .css entries', async () => {
+    it('returns noNamespaceRef when zip has only namespace-free .css entries', async () => {
       const zip = new JSZip();
       zip.file('themes/lightning.css', '.foo { color: red; }');
       zip.file('themes/notes.txt', 'this is not css');
@@ -195,7 +195,7 @@ describe('CustomCssRegistry', () => {
       });
       registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
       const verdict = await registry.scanResource('bundle');
-      expect(verdict).to.equal('clean');
+      expect(verdict).to.equal('noNamespaceRef');
     });
   });
 
@@ -244,7 +244,7 @@ describe('CustomCssRegistry', () => {
   describe('scanOmniScriptStylesheets()', () => {
     it('returns empty result when registry is not enabled', async () => {
       const result = await registry.scanOmniScriptStylesheets({ lightning: 'foo', newport: 'bar' });
-      expect(result.dirtyStylesheets).to.deep.equal([]);
+      expect(result.stylesheetsWithNamespaceRefs).to.deep.equal([]);
     });
 
     it('returns empty result when stylesheet object is missing or non-object', async () => {
@@ -254,9 +254,9 @@ describe('CustomCssRegistry', () => {
       const r1 = await registry.scanOmniScriptStylesheets(undefined);
       const r2 = await registry.scanOmniScriptStylesheets(null);
       const r3 = await registry.scanOmniScriptStylesheets('a string');
-      expect(r1.dirtyStylesheets).to.deep.equal([]);
-      expect(r2.dirtyStylesheets).to.deep.equal([]);
-      expect(r3.dirtyStylesheets).to.deep.equal([]);
+      expect(r1.stylesheetsWithNamespaceRefs).to.deep.equal([]);
+      expect(r2.stylesheetsWithNamespaceRefs).to.deep.equal([]);
+      expect(r3.stylesheetsWithNamespaceRefs).to.deep.equal([]);
     });
 
     it('skips empty / falsy variant names', async () => {
@@ -276,14 +276,15 @@ describe('CustomCssRegistry', () => {
       expect(queryCount).to.equal(0);
     });
 
-    it('returns dirty stylesheet names in variant order, deduped via cache', async () => {
+    it('dedupes a stylesheet referenced from multiple variants and only queries once', async () => {
       const conn = buildMockConnection({
         records: [{ Id: '081xx', Name: 'sharedSheet', ContentType: 'text/css', BodyLength: 30 }],
         body: '.vlocity_cmt-foo {}',
       });
       registry.init(conn as any, 'vlocity_cmt', buildMockMessages());
 
-      // Both variants point at the same resource — cache prevents two SOQLs.
+      // Both variants point at the same resource — cache prevents two SOQLs and
+      // the result array collapses the duplicate.
       let queryCount = 0;
       (conn as any).query = () => {
         queryCount++;
@@ -300,7 +301,7 @@ describe('CustomCssRegistry', () => {
         newportRtl: '',
       });
 
-      expect(result.dirtyStylesheets).to.deep.equal(['sharedSheet', 'sharedSheet']);
+      expect(result.stylesheetsWithNamespaceRefs).to.deep.equal(['sharedSheet']);
       expect(queryCount).to.equal(1);
     });
   });

--- a/test/migration/flexcard-custom-css.test.ts
+++ b/test/migration/flexcard-custom-css.test.ts
@@ -1,0 +1,261 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, camelcase, comma-dangle */
+import { expect } from 'chai';
+import { CardMigrationTool } from '../../src/migration/flexcard';
+import { CustomCssRegistry } from '../../src/migration/CustomCssRegistry';
+import { NameMappingRegistry } from '../../src/migration/NameMappingRegistry';
+import { initializeDataModelService } from '../../src/utils/dataModelService';
+import { OmnistudioOrgDetails } from '../../src/utils/orgUtils';
+
+/**
+ * Integration tests for FlexCard's two custom-CSS scan paths:
+ * 1. `Definition__c.customStyleSheet` → StaticResource lookup + scan (cached)
+ * 2. `Styles__c.customStyles`         → raw inline-CSS substring check
+ *
+ * Runs against the standard data model so we use the unprefixed field names
+ * (PropertySetConfig, StylingConfiguration, …).
+ */
+describe('FlexCard — Custom CSS namespace scan', () => {
+  let cardTool: CardMigrationTool;
+  let mockConnection: any;
+  let mockMessages: any;
+  let requestCount: number;
+
+  const STATIC_RESOURCE_NAME_REGEX = /FROM StaticResource WHERE Name = '([^']+)'/;
+  const STATIC_RESOURCE_ID_REGEX = /StaticResource\/([^/]+)\/Body/;
+
+  function setupMockConnection(opts: {
+    staticResources?: { [name: string]: { Id: string; ContentType: string; BodyLength: number } };
+    bodies?: { [id: string]: any };
+  }) {
+    requestCount = 0;
+    mockConnection = {
+      query: (sql: string) => {
+        const match = STATIC_RESOURCE_NAME_REGEX.exec(sql);
+        if (match && opts.staticResources && opts.staticResources[match[1]]) {
+          const r = opts.staticResources[match[1]];
+          return Promise.resolve({
+            totalSize: 1,
+            records: [{ Id: r.Id, Name: match[1], ContentType: r.ContentType, BodyLength: r.BodyLength }],
+          });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      },
+      request: (req: any) => {
+        requestCount++;
+        const url = req.url || '';
+        const idMatch = STATIC_RESOURCE_ID_REGEX.exec(url);
+        const id = idMatch ? idMatch[1] : '';
+        return Promise.resolve(opts.bodies?.[id] ?? '');
+      },
+      getApiVersion: () => '60.0',
+    };
+  }
+
+  beforeEach(() => {
+    NameMappingRegistry.getInstance().clear();
+    CustomCssRegistry.getInstance().reset();
+
+    const mockOrgDetails: OmnistudioOrgDetails = {
+      packageDetails: { version: '1.0.0', namespace: 'omnistudio' },
+      omniStudioOrgPermissionEnabled: true, // standard data model
+      orgDetails: { Name: 'Test Org', Id: '00D000000000000' },
+      dataModel: 'Standard',
+      hasValidNamespace: true,
+      isFoundationPackage: false,
+      isOmnistudioMetadataAPIEnabled: false,
+    };
+    initializeDataModelService(mockOrgDetails);
+
+    setupMockConnection({});
+
+    mockMessages = {
+      getMessage: (key: string, args?: string[]) => {
+        if (key === 'customCssStylesheetNamespaceWarning') {
+          return `Custom CSS stylesheet '${args?.[0]}' has namespace references, styles may break after migration.`;
+        }
+        if (key === 'customCssInlineNamespaceWarning') {
+          return 'Custom inline CSS has namespace references, styles may break after migration.';
+        }
+        if (key === 'cardNameChangeMessage') {
+          return `The card name '${args?.[0]}' will be changed to '${args?.[1]}'`;
+        }
+        return `Mock message: ${key}`;
+      },
+    };
+  });
+
+  function makeTool(namespace: string): CardMigrationTool {
+    return new CardMigrationTool(namespace, mockConnection, {} as any, mockMessages, {} as any, false);
+  }
+
+  function makeFlexCard(opts: { definition?: any; styles?: any }) {
+    const record: any = {
+      Id: 'fc-css-1',
+      Name: 'CleanFlex',
+      AuthorName: 'Tester',
+      IsActive: true,
+      OmniUiCardType: 'Parent',
+      VersionNumber: 1,
+    };
+    if (opts.definition !== undefined) record.PropertySetConfig = JSON.stringify(opts.definition);
+    if (opts.styles !== undefined) record.StylingConfiguration = JSON.stringify(opts.styles);
+    return record;
+  }
+
+  describe('Definition__c.customStyleSheet (StaticResource path)', () => {
+    it('emits a warning and bumps status when the static resource body contains the namespace', async () => {
+      setupMockConnection({
+        staticResources: { dirtyCss: { Id: '081A1', ContentType: 'text/css', BodyLength: 20 } },
+        bodies: { '081A1': '.vlocity_cmt-card {}' },
+      });
+      cardTool = makeTool('vlocity_cmt');
+
+      const fc = makeFlexCard({
+        definition: { states: [], customStyleSheet: 'dirtyCss' },
+      });
+      const result = await (cardTool as any).processFlexCard(fc, new Set<string>(), new Map<string, string>());
+
+      expect(result.warnings.some((w: string) => w.includes("'dirtyCss'"))).to.equal(true);
+      expect(result.migrationStatus).to.equal('Warnings');
+    });
+
+    it('does not warn when the static resource body has no namespace match', async () => {
+      setupMockConnection({
+        staticResources: { cleanCss: { Id: '081A2', ContentType: 'text/css', BodyLength: 20 } },
+        bodies: { '081A2': '.foo { color: red; }' },
+      });
+      cardTool = makeTool('vlocity_cmt');
+
+      const fc = makeFlexCard({
+        definition: { states: [], customStyleSheet: 'cleanCss' },
+      });
+      const result = await (cardTool as any).processFlexCard(fc, new Set<string>(), new Map<string, string>());
+
+      expect(result.warnings.find((w: string) => w.includes('namespace references'))).to.equal(undefined);
+      expect(result.migrationStatus).to.equal('Ready for migration');
+    });
+
+    it('skips silently when customStyleSheet references a missing StaticResource', async () => {
+      setupMockConnection({}); // no records
+      cardTool = makeTool('vlocity_cmt');
+
+      const fc = makeFlexCard({
+        definition: { states: [], customStyleSheet: 'doesNotExist' },
+      });
+      const result = await (cardTool as any).processFlexCard(fc, new Set<string>(), new Map<string, string>());
+
+      expect(result.warnings.find((w: string) => w.includes('namespace references'))).to.equal(undefined);
+      expect(result.migrationStatus).to.equal('Ready for migration');
+      expect(requestCount).to.equal(0);
+    });
+
+    it('skips entirely when customStyleSheet is empty/missing', async () => {
+      setupMockConnection({});
+      cardTool = makeTool('vlocity_cmt');
+
+      const fc = makeFlexCard({
+        definition: { states: [] }, // no customStyleSheet key
+      });
+      await (cardTool as any).processFlexCard(fc, new Set<string>(), new Map<string, string>());
+
+      // No StaticResource SOQL should have been issued.
+      expect(requestCount).to.equal(0);
+    });
+  });
+
+  describe('Styles__c.customStyles (inline CSS path)', () => {
+    it('emits the inline-CSS warning when customStyles contains the namespace', async () => {
+      setupMockConnection({});
+      cardTool = makeTool('vlocity_cmt');
+
+      const fc = makeFlexCard({
+        definition: { states: [] },
+        styles: { customStyles: '.vlocity_cmt-foo { display: none; }' },
+      });
+      const result = await (cardTool as any).processFlexCard(fc, new Set<string>(), new Map<string, string>());
+
+      expect(result.warnings.some((w: string) => w.includes('Custom inline CSS'))).to.equal(true);
+      expect(result.migrationStatus).to.equal('Warnings');
+      // Pure substring match — no SOQL, no REST.
+      expect(requestCount).to.equal(0);
+    });
+
+    it('does not warn when customStyles has no namespace match', async () => {
+      setupMockConnection({});
+      cardTool = makeTool('vlocity_cmt');
+
+      const fc = makeFlexCard({
+        definition: { states: [] },
+        styles: { customStyles: '.classxyz { color: red; }' },
+      });
+      const result = await (cardTool as any).processFlexCard(fc, new Set<string>(), new Map<string, string>());
+
+      expect(result.warnings.find((w: string) => w.includes('namespace references'))).to.equal(undefined);
+      expect(result.migrationStatus).to.equal('Ready for migration');
+    });
+
+    it('skips when Styles__c is missing entirely', async () => {
+      setupMockConnection({});
+      cardTool = makeTool('vlocity_cmt');
+
+      const fc = makeFlexCard({
+        definition: { states: [] },
+        // no styles key
+      });
+      const result = await (cardTool as any).processFlexCard(fc, new Set<string>(), new Map<string, string>());
+
+      expect(result.warnings.find((w: string) => w.includes('Custom inline CSS'))).to.equal(undefined);
+    });
+
+    it('skips when customStyles is an empty string', async () => {
+      setupMockConnection({});
+      cardTool = makeTool('vlocity_cmt');
+
+      const fc = makeFlexCard({
+        definition: { states: [] },
+        styles: { customStyles: '' },
+      });
+      const result = await (cardTool as any).processFlexCard(fc, new Set<string>(), new Map<string, string>());
+
+      expect(result.warnings.find((w: string) => w.includes('Custom inline CSS'))).to.equal(undefined);
+    });
+  });
+
+  describe('Combined: both paths can fire on the same FlexCard', () => {
+    it('emits two warnings when both Definition stylesheet AND inline CSS match', async () => {
+      setupMockConnection({
+        staticResources: { dirtyCss: { Id: '081A1', ContentType: 'text/css', BodyLength: 20 } },
+        bodies: { '081A1': '.vlocity_cmt-card {}' },
+      });
+      cardTool = makeTool('vlocity_cmt');
+
+      const fc = makeFlexCard({
+        definition: { states: [], customStyleSheet: 'dirtyCss' },
+        styles: { customStyles: '.vlocity_cmt-foo {}' },
+      });
+      const result = await (cardTool as any).processFlexCard(fc, new Set<string>(), new Map<string, string>());
+
+      expect(result.warnings.filter((w: string) => w.includes('namespace references')).length).to.equal(2);
+      expect(result.warnings.some((w: string) => w.includes("'dirtyCss'"))).to.equal(true);
+      expect(result.warnings.some((w: string) => w.includes('Custom inline CSS'))).to.equal(true);
+      expect(result.migrationStatus).to.equal('Warnings');
+    });
+  });
+
+  describe('Empty namespace short-circuits both paths', () => {
+    it('runs no SOQL and no REST when namespace is empty, even with both inputs present', async () => {
+      setupMockConnection({});
+      cardTool = makeTool(''); // empty namespace → registry disabled
+
+      const fc = makeFlexCard({
+        definition: { states: [], customStyleSheet: 'something' },
+        styles: { customStyles: '.vlocity_cmt-foo {}' },
+      });
+      const result = await (cardTool as any).processFlexCard(fc, new Set<string>(), new Map<string, string>());
+
+      // No CSS warning should be emitted, and no StaticResource lookup should happen.
+      expect(result.warnings.find((w: string) => w.includes('namespace references'))).to.equal(undefined);
+      expect(requestCount).to.equal(0);
+    });
+  });
+});

--- a/test/migration/flexcard-custom-css.test.ts
+++ b/test/migration/flexcard-custom-css.test.ts
@@ -105,29 +105,29 @@ describe('FlexCard — Custom CSS namespace scan', () => {
   describe('Definition__c.customStyleSheet (StaticResource path)', () => {
     it('emits a warning and bumps status when the static resource body contains the namespace', async () => {
       setupMockConnection({
-        staticResources: { dirtyCss: { Id: '081A1', ContentType: 'text/css', BodyLength: 20 } },
+        staticResources: { flaggedCss: { Id: '081A1', ContentType: 'text/css', BodyLength: 20 } },
         bodies: { '081A1': '.vlocity_cmt-card {}' },
       });
       cardTool = makeTool('vlocity_cmt');
 
       const fc = makeFlexCard({
-        definition: { states: [], customStyleSheet: 'dirtyCss' },
+        definition: { states: [], customStyleSheet: 'flaggedCss' },
       });
       const result = await (cardTool as any).processFlexCard(fc, new Set<string>(), new Map<string, string>());
 
-      expect(result.warnings.some((w: string) => w.includes("'dirtyCss'"))).to.equal(true);
+      expect(result.warnings.some((w: string) => w.includes("'flaggedCss'"))).to.equal(true);
       expect(result.migrationStatus).to.equal('Warnings');
     });
 
     it('does not warn when the static resource body has no namespace match', async () => {
       setupMockConnection({
-        staticResources: { cleanCss: { Id: '081A2', ContentType: 'text/css', BodyLength: 20 } },
+        staticResources: { safeCss: { Id: '081A2', ContentType: 'text/css', BodyLength: 20 } },
         bodies: { '081A2': '.foo { color: red; }' },
       });
       cardTool = makeTool('vlocity_cmt');
 
       const fc = makeFlexCard({
-        definition: { states: [], customStyleSheet: 'cleanCss' },
+        definition: { states: [], customStyleSheet: 'safeCss' },
       });
       const result = await (cardTool as any).processFlexCard(fc, new Set<string>(), new Map<string, string>());
 
@@ -224,19 +224,19 @@ describe('FlexCard — Custom CSS namespace scan', () => {
   describe('Combined: both paths can fire on the same FlexCard', () => {
     it('emits two warnings when both Definition stylesheet AND inline CSS match', async () => {
       setupMockConnection({
-        staticResources: { dirtyCss: { Id: '081A1', ContentType: 'text/css', BodyLength: 20 } },
+        staticResources: { flaggedCss: { Id: '081A1', ContentType: 'text/css', BodyLength: 20 } },
         bodies: { '081A1': '.vlocity_cmt-card {}' },
       });
       cardTool = makeTool('vlocity_cmt');
 
       const fc = makeFlexCard({
-        definition: { states: [], customStyleSheet: 'dirtyCss' },
+        definition: { states: [], customStyleSheet: 'flaggedCss' },
         styles: { customStyles: '.vlocity_cmt-foo {}' },
       });
       const result = await (cardTool as any).processFlexCard(fc, new Set<string>(), new Map<string, string>());
 
       expect(result.warnings.filter((w: string) => w.includes('namespace references')).length).to.equal(2);
-      expect(result.warnings.some((w: string) => w.includes("'dirtyCss'"))).to.equal(true);
+      expect(result.warnings.some((w: string) => w.includes("'flaggedCss'"))).to.equal(true);
       expect(result.warnings.some((w: string) => w.includes('Custom inline CSS'))).to.equal(true);
       expect(result.migrationStatus).to.equal('Warnings');
     });

--- a/test/migration/omniscript-custom-css.test.ts
+++ b/test/migration/omniscript-custom-css.test.ts
@@ -142,7 +142,7 @@ describe('OmniScript — Custom CSS namespace scan', () => {
   it('does not warn when the stylesheet body has no namespace match', async () => {
     setupMockConnection({
       staticResources: {
-        cleanCss: { Id: '081SR2', ContentType: 'text/css', BodyLength: 30 },
+        safeCss: { Id: '081SR2', ContentType: 'text/css', BodyLength: 30 },
       },
       bodies: { '081SR2': '.something-else { color: red; }' },
     });
@@ -150,7 +150,7 @@ describe('OmniScript — Custom CSS namespace scan', () => {
     (omniScriptTool as any).getAllElementsForOmniScript = () => Promise.resolve([]);
 
     const os = makeOmniscript({
-      stylesheet: { lightning: 'cleanCss', newport: '', lightningRtl: '', newportRtl: '' },
+      stylesheet: { lightning: 'safeCss', newport: '', lightningRtl: '', newportRtl: '' },
     });
     const result = await (omniScriptTool as any).processOmniScript(
       os,

--- a/test/migration/omniscript-custom-css.test.ts
+++ b/test/migration/omniscript-custom-css.test.ts
@@ -1,0 +1,271 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, camelcase, comma-dangle */
+import { expect } from 'chai';
+import { OmniScriptMigrationTool, OmniScriptExportType } from '../../src/migration/omniscript';
+import { CustomCssRegistry } from '../../src/migration/CustomCssRegistry';
+import { NameMappingRegistry } from '../../src/migration/NameMappingRegistry';
+import { initializeDataModelService } from '../../src/utils/dataModelService';
+import { OmnistudioOrgDetails } from '../../src/utils/orgUtils';
+
+/**
+ * Integration tests for `processOmniScript`'s stylesheet-namespace scan path.
+ * Runs against the standard data model so we can use plain field names
+ * (PropertySetConfig, Type, SubType, …) instead of namespaced versions.
+ */
+describe('OmniScript — Custom CSS namespace scan', () => {
+  let omniScriptTool: OmniScriptMigrationTool;
+  let mockConnection: any;
+  let mockMessages: any;
+  let queryCount: number;
+  let requestCount: number;
+
+  /** A reusable mock that lets the test customise per-call query/request behaviour. */
+  const STATIC_RESOURCE_NAME_REGEX = /FROM StaticResource WHERE Name = '([^']+)'/;
+  const STATIC_RESOURCE_ID_REGEX = /StaticResource\/([^/]+)\/Body/;
+
+  function setupMockConnection(opts: {
+    staticResources?: { [name: string]: { Id: string; ContentType: string; BodyLength: number } };
+    bodies?: { [id: string]: any };
+  }) {
+    queryCount = 0;
+    requestCount = 0;
+    mockConnection = {
+      // Standard query returns nothing unless overridden by the test (we only need
+      // the StaticResource branch here).
+      query: (sql: string) => {
+        queryCount++;
+        // Look for a StaticResource Name = 'xxx' filter and return that record if known.
+        const match = STATIC_RESOURCE_NAME_REGEX.exec(sql);
+        if (match && opts.staticResources && opts.staticResources[match[1]]) {
+          const r = opts.staticResources[match[1]];
+          return Promise.resolve({
+            totalSize: 1,
+            records: [{ Id: r.Id, Name: match[1], ContentType: r.ContentType, BodyLength: r.BodyLength }],
+          });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      },
+      request: (req: any) => {
+        requestCount++;
+        const url = req.url || '';
+        const idMatch = STATIC_RESOURCE_ID_REGEX.exec(url);
+        const id = idMatch ? idMatch[1] : '';
+        return Promise.resolve(opts.bodies?.[id] ?? '');
+      },
+      getApiVersion: () => '60.0',
+    };
+  }
+
+  beforeEach(() => {
+    NameMappingRegistry.getInstance().clear();
+    CustomCssRegistry.getInstance().reset();
+
+    const mockOrgDetails: OmnistudioOrgDetails = {
+      packageDetails: { version: '1.0.0', namespace: 'omnistudio' },
+      omniStudioOrgPermissionEnabled: true, // forces standard data model
+      orgDetails: { Name: 'Test Org', Id: '00D000000000000' },
+      dataModel: 'Standard',
+      hasValidNamespace: true,
+      isFoundationPackage: false,
+      isOmnistudioMetadataAPIEnabled: false,
+    };
+    initializeDataModelService(mockOrgDetails);
+
+    setupMockConnection({});
+
+    mockMessages = {
+      getMessage: (key: string, args?: string[]) => {
+        if (key === 'customCssStylesheetNamespaceWarning') {
+          return `Custom CSS stylesheet '${args?.[0]}' has namespace references, styles may break after migration.`;
+        }
+        if (key === 'customCssInlineNamespaceWarning') {
+          return 'Custom inline CSS has namespace references, styles may break after migration.';
+        }
+        return `Mock message: ${key}`;
+      },
+    };
+  });
+
+  function makeTool(namespace: string): OmniScriptMigrationTool {
+    return new OmniScriptMigrationTool(
+      OmniScriptExportType.All,
+      namespace,
+      mockConnection,
+      {} as any,
+      mockMessages,
+      {} as any,
+      false
+    );
+  }
+
+  function makeOmniscript(propertySetConfig: any) {
+    return {
+      Id: 'op-css-1',
+      Name: 'TestCssOS',
+      Type: 'TestType',
+      SubType: 'TestSubType',
+      Language: 'English',
+      VersionNumber: '1',
+      IsIntegrationProcedure: false,
+      IsWebCompEnabled: true,
+      IsActive: true,
+      PropertySetConfig: JSON.stringify(propertySetConfig),
+    };
+  }
+
+  it('emits a warning and bumps status when the stylesheet body contains the namespace', async () => {
+    setupMockConnection({
+      staticResources: {
+        myCustomCss: { Id: '081SR1', ContentType: 'text/css', BodyLength: 30 },
+      },
+      bodies: {
+        '081SR1': '.vlocity_cmt-card { display: none; }',
+      },
+    });
+    omniScriptTool = makeTool('vlocity_cmt');
+    (omniScriptTool as any).getAllElementsForOmniScript = () => Promise.resolve([]);
+
+    const os = makeOmniscript({
+      stylesheet: { lightning: 'myCustomCss', newport: '', lightningRtl: '', newportRtl: '' },
+    });
+    const result = await (omniScriptTool as any).processOmniScript(
+      os,
+      new Set<string>(),
+      new Set<string>(),
+      new Set<string>(),
+      new Map<string, string>()
+    );
+
+    expect(result.warnings.some((w: string) => w.includes("'myCustomCss'"))).to.equal(true);
+    expect(result.migrationStatus).to.equal('Warnings');
+  });
+
+  it('does not warn when the stylesheet body has no namespace match', async () => {
+    setupMockConnection({
+      staticResources: {
+        cleanCss: { Id: '081SR2', ContentType: 'text/css', BodyLength: 30 },
+      },
+      bodies: { '081SR2': '.something-else { color: red; }' },
+    });
+    omniScriptTool = makeTool('vlocity_cmt');
+    (omniScriptTool as any).getAllElementsForOmniScript = () => Promise.resolve([]);
+
+    const os = makeOmniscript({
+      stylesheet: { lightning: 'cleanCss', newport: '', lightningRtl: '', newportRtl: '' },
+    });
+    const result = await (omniScriptTool as any).processOmniScript(
+      os,
+      new Set<string>(),
+      new Set<string>(),
+      new Set<string>(),
+      new Map<string, string>()
+    );
+
+    expect(result.warnings.find((w: string) => w.includes('namespace references'))).to.equal(undefined);
+    expect(result.migrationStatus).to.equal('Ready for migration');
+  });
+
+  it('skips silently when the referenced StaticResource does not exist', async () => {
+    setupMockConnection({}); // no records
+    omniScriptTool = makeTool('vlocity_cmt');
+    (omniScriptTool as any).getAllElementsForOmniScript = () => Promise.resolve([]);
+
+    const os = makeOmniscript({
+      stylesheet: { lightning: 'doesNotExist', newport: '', lightningRtl: '', newportRtl: '' },
+    });
+    const result = await (omniScriptTool as any).processOmniScript(
+      os,
+      new Set<string>(),
+      new Set<string>(),
+      new Set<string>(),
+      new Map<string, string>()
+    );
+
+    expect(result.warnings.find((w: string) => w.includes('namespace references'))).to.equal(undefined);
+    expect(result.migrationStatus).to.equal('Ready for migration');
+    // SOQL was issued, but no body fetch.
+    expect(requestCount).to.equal(0);
+  });
+
+  it('does not run any SOQL or REST when namespace is empty', async () => {
+    setupMockConnection({});
+    omniScriptTool = makeTool(''); // empty namespace → registry disabled
+    (omniScriptTool as any).getAllElementsForOmniScript = () => Promise.resolve([]);
+
+    const os = makeOmniscript({
+      stylesheet: { lightning: 'whatever', newport: '', lightningRtl: '', newportRtl: '' },
+    });
+    await (omniScriptTool as any).processOmniScript(
+      os,
+      new Set<string>(),
+      new Set<string>(),
+      new Set<string>(),
+      new Map<string, string>()
+    );
+
+    expect(queryCount).to.equal(0);
+    expect(requestCount).to.equal(0);
+  });
+
+  it('caches the resource: scanning the same name across two OmniScripts triggers only one SOQL + one fetch', async () => {
+    setupMockConnection({
+      staticResources: {
+        sharedCss: { Id: '081SR3', ContentType: 'text/css', BodyLength: 30 },
+      },
+      bodies: { '081SR3': '.vlocity_cmt-x {}' },
+    });
+    omniScriptTool = makeTool('vlocity_cmt');
+    (omniScriptTool as any).getAllElementsForOmniScript = () => Promise.resolve([]);
+
+    const os1 = makeOmniscript({
+      stylesheet: { lightning: 'sharedCss', newport: '', lightningRtl: '', newportRtl: '' },
+    });
+    const os2 = {
+      ...makeOmniscript({ stylesheet: { lightning: 'sharedCss', newport: '', lightningRtl: '', newportRtl: '' } }),
+      Id: 'op-css-2',
+      Name: 'OtherOS',
+    };
+
+    const r1 = await (omniScriptTool as any).processOmniScript(
+      os1,
+      new Set<string>(),
+      new Set<string>(),
+      new Set<string>(),
+      new Map<string, string>()
+    );
+    const r2 = await (omniScriptTool as any).processOmniScript(
+      os2,
+      new Set<string>(),
+      new Set<string>(),
+      new Set<string>(),
+      new Map<string, string>()
+    );
+
+    expect(r1.warnings.some((w: string) => w.includes("'sharedCss'"))).to.equal(true);
+    expect(r2.warnings.some((w: string) => w.includes("'sharedCss'"))).to.equal(true);
+    // SOQL is invoked once for the StaticResource lookup. Other SOQLs may run
+    // (for OmniScript element retrieval, e.g.), so we only assert the request
+    // (body fetch) count, which is dedicated to StaticResource bodies.
+    expect(requestCount).to.equal(1);
+  });
+
+  it('skips the scan entirely when PropertySetConfig has no stylesheet block', async () => {
+    setupMockConnection({});
+    omniScriptTool = makeTool('vlocity_cmt');
+    (omniScriptTool as any).getAllElementsForOmniScript = () => Promise.resolve([]);
+
+    const os = makeOmniscript({
+      // no stylesheet key, just unrelated config
+      persistentComponent: [],
+    });
+    const result = await (omniScriptTool as any).processOmniScript(
+      os,
+      new Set<string>(),
+      new Set<string>(),
+      new Set<string>(),
+      new Map<string, string>()
+    );
+
+    expect(result.warnings.find((w: string) => w.includes('namespace references'))).to.equal(undefined);
+    expect(requestCount).to.equal(0);
+  });
+});


### PR DESCRIPTION
Problem - During the migration we are changing the patterns at several places where the occurences of namespaces are getting changed to c (For example: vlocity_ins/function -> c/function etc). In doing so the html structure will change and if any customer has implemented his custom css which has the namespace dependency might break.

Solution - For this scenario we are scanning through the custom css files used in Omniscripts and Flexcards, and showing a warning to the user during assessment if there are any occurrences of the namespace in the css file. There might be other patterns possible which wee are not certain of but this PR will cover the namespace scenario.

### What does this PR do?

### What issues does this PR fix or reference?
