### PR TITLE
@W-19835755 - Detect custom LWC cross-namespace risks in assess and migrate modes

### DIFF
--- a/messages/info.json
+++ b/messages/info.json
@@ -1,11 +1,17 @@
 {
-  "commandDescription": "print a greeting and your org IDs",
-  "nameFlagDescription": "name to print",
-  "forceFlagDescription": "example boolean flag",
+  "commandDescription": "Assess OmniStudio components for post-migration cross-namespace LWC risks",
+  "namespaceFlagDescription": "Namespace of the managed package (default: vlocity_ins)",
+  "onlyFlagDescription": "Assess a single component type: fc | os | ip | dr",
+  "allVersionsDescription": "Assess all versions of a component",
   "errorNoOrgResults": "No results found for the org '%s'.",
+  "alreadyStandardModel": "Assessment skipped for org %s: org already uses the standard data model.",
+  "invalidNamespace": "Invalid namespace value: %s. Try again with the correct namespace value.",
+  "invalidOnlyFlag": "Invalid flag, valid options are: os | ip | fc | dr",
+  "noIssuesFound": "No cross-namespace LWC issues detected.",
+  "assessSummary": "%s component(s) have potential cross-namespace LWC issues.",
   "examples": [
-    "sfdx omnistudio:migration:info --targetusername myOrg@example.com --targetdevhubusername devhub@org.com",
-    "sfdx omnistudio:migration:info --name myname --targetusername myOrg@example.com"
-  ],
-  "allVersionsDescription": "Migrate all versions of a component"
+    "omnistudio:migration:info -u orguser@domain.com --namespace=vlocity_ins",
+    "omnistudio:migration:info -u orguser@domain.com --namespace=vlocity_ins --only=fc",
+    "omnistudio:migration:info -u orguser@domain.com --namespace=vlocity_ins --only=os"
+  ]
 }

--- a/src/commands/omnistudio/migration/info.ts
+++ b/src/commands/omnistudio/migration/info.ts
@@ -5,18 +5,24 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as os from 'os';
-import { flags, SfdxCommand } from '@salesforce/command';
-import { Messages, SfdxError } from '@salesforce/core';
-import { AnyJson } from '@salesforce/ts-types';
+import { flags } from '@salesforce/command';
+import { Messages } from '@salesforce/core';
+import '../../../utils/prototypes';
+import OmniStudioBaseCommand from '../../basecommand';
+import { CardMigrationTool } from '../../../migration/flexcard';
+import { OmniScriptExportType, OmniScriptMigrationTool } from '../../../migration/omniscript';
+import { DataRaptorMigrationTool } from '../../../migration/dataraptor';
+import { AssessResult, MigrationTool } from '../../../migration/interfaces';
+import { DebugTimer, OrgUtils } from '../../../utils';
+import { ResultsBuilder } from '../../../utils/resultsbuilder';
+import { Logger } from '../../../utils/logger';
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);
 
-// Load the specific messages for this file. Messages from @salesforce/command, @salesforce/core,
-// or any library that is using the messages framework can also be loaded this way.
 const messages = Messages.loadMessages('@salesforce/plugin-omnistudio-migration-tool', 'info');
 
-export default class Org extends SfdxCommand {
+export default class Info extends OmniStudioBaseCommand {
   public static description = messages.getMessage('commandDescription');
 
   public static examples = messages.getMessage('examples').split(os.EOL);
@@ -24,10 +30,13 @@ export default class Org extends SfdxCommand {
   public static args = [{ name: 'file' }];
 
   protected static flagsConfig = {
-    // flag with a value (-n, --name=VALUE)
-    name: flags.string({
+    namespace: flags.string({
       char: 'n',
-      description: messages.getMessage('nameFlagDescription'),
+      description: messages.getMessage('namespaceFlagDescription'),
+    }),
+    only: flags.string({
+      char: 'o',
+      description: messages.getMessage('onlyFlagDescription'),
     }),
     allversions: flags.boolean({
       char: 'a',
@@ -36,61 +45,129 @@ export default class Org extends SfdxCommand {
     }),
   };
 
-  // Comment this out if your command does not require an org username
-  protected static requiresUsername = true;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public async run(): Promise<any> {
+    const namespace = (this.flags.namespace || 'vlocity_ins') as string;
+    const apiVersion = (this.flags.apiversion || '55.0') as string;
+    const assessOnly = (this.flags.only || '') as string;
+    const allVersions = (this.flags.allversions as boolean) || false;
 
-  // Comment this out if your command does not support a hub org username
-  protected static supportsDevhubUsername = true;
+    Logger.initialiseLogger(this.ux, this.logger);
+    this.logger = Logger.logger;
 
-  // Set this to true if your command requires a project workspace; 'requiresProject' is false by default
-  protected static requiresProject = false;
-
-  public async run(): Promise<AnyJson> {
-    const name = (this.flags.name || 'world') as string;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const allVersions = this.flags.allversions || false;
-
-    // this.org is guaranteed because requiresUsername=true, as opposed to supportsUsername
     const conn = this.org.getConnection();
-    const query = 'Select Name, TrialExpirationDate from Organization';
+    conn.setApiVersion(apiVersion);
 
-    // The type we are querying for
-    interface Organization {
-      Name: string;
-      TrialExpirationDate: string;
+    // Validate org before proceeding
+    const orgs = await OrgUtils.getOrgDetails(conn, namespace);
+
+    if (orgs.omniStudioOrgPermissionEnabled) {
+      Logger.error(messages.getMessage('alreadyStandardModel', [orgs.orgDetails.Id]));
+      return;
+    } else if (!orgs.hasValidNamespace) {
+      Logger.error(messages.getMessage('invalidNamespace', [namespace]));
+      return;
     }
 
-    // Query the org
-    const result = await conn.query<Organization>(query);
+    DebugTimer.getInstance().start();
 
-    // Organization will always return one result, but this is an example of throwing an error
-    // The output and --json will automatically be handled for you.
-    if (!result.records || result.records.length <= 0) {
-      throw new SfdxError(messages.getMessage('errorNoOrgResults', [this.org.getOrgId()]));
+    // Register tools to assess based on --only flag
+    const assessObjects: MigrationTool[] = [];
+    if (!assessOnly) {
+      assessObjects.push(
+        new DataRaptorMigrationTool(namespace, conn, this.logger, messages, this.ux),
+        new OmniScriptMigrationTool(
+          OmniScriptExportType.All,
+          namespace,
+          conn,
+          this.logger,
+          messages,
+          this.ux,
+          allVersions
+        ),
+        new CardMigrationTool(namespace, conn, this.logger, messages, this.ux, allVersions)
+      );
+    } else {
+      switch (assessOnly) {
+        case 'os':
+          assessObjects.push(
+            new OmniScriptMigrationTool(
+              OmniScriptExportType.OS,
+              namespace,
+              conn,
+              this.logger,
+              messages,
+              this.ux,
+              allVersions
+            )
+          );
+          break;
+        case 'ip':
+          assessObjects.push(
+            new OmniScriptMigrationTool(
+              OmniScriptExportType.IP,
+              namespace,
+              conn,
+              this.logger,
+              messages,
+              this.ux,
+              allVersions
+            )
+          );
+          break;
+        case 'fc':
+          assessObjects.push(new CardMigrationTool(namespace, conn, this.logger, messages, this.ux, allVersions));
+          break;
+        case 'dr':
+          assessObjects.push(new DataRaptorMigrationTool(namespace, conn, this.logger, messages, this.ux));
+          break;
+        default:
+          throw new Error(messages.getMessage('invalidOnlyFlag'));
+      }
     }
 
-    // Organization always only returns one result
-    const orgName = result.records[0].Name;
-    const trialExpirationDate = result.records[0].TrialExpirationDate;
-
-    let outputString = `Hello ${name}! This is org: ${orgName}`;
-    if (trialExpirationDate) {
-      const date = new Date(trialExpirationDate).toDateString();
-      outputString = `${outputString} and I will be around until ${date}!`;
-    }
-    this.ux.log(outputString);
-
-    // this.hubOrg is NOT guaranteed because supportsHubOrgUsername=true, as opposed to requiresHubOrgUsername.
-    if (this.hubOrg) {
-      const hubOrgId = this.hubOrg.getOrgId();
-      this.ux.log(`My hub org id is: ${hubOrgId}`);
+    // Run assessment on each tool
+    const allAssessResults: AssessResult[] = [];
+    for (const tool of assessObjects) {
+      Logger.ux.log('Assessing: ' + tool.getName());
+      const results = await tool.assess();
+      allAssessResults.push(...results);
     }
 
-    if (allVersions) {
-      outputString = `${outputString} and all versions will be migrated`;
+    // Log summary to console
+    if (allAssessResults.length === 0) {
+      Logger.ux.log(messages.getMessage('noIssuesFound'));
+    } else {
+      Logger.ux.log(messages.getMessage('assessSummary', [String(allAssessResults.length)]));
+      for (const result of allAssessResults) {
+        Logger.ux.log(`\n[${result.componentType}] ${result.name}`);
+        for (const warning of result.warnings) {
+          Logger.ux.log('  ' + warning);
+        }
+      }
     }
 
-    // Return an object to be displayed with --json
-    return { orgId: this.org.getOrgId(), outputString };
+    // Generate HTML report (same UX as migrate mode)
+    const migratedObjects = allAssessResults.map((r) => ({
+      name: `[${r.componentType}] ${r.name}`,
+      data: [
+        {
+          id: r.name,
+          name: r.name,
+          status: 'Warning',
+          errors: r.warnings,
+          migratedId: undefined,
+          migratedName: '',
+          warnings: [],
+        },
+      ],
+    }));
+
+    await ResultsBuilder.generate(migratedObjects, conn.instanceUrl);
+
+    const timer = DebugTimer.getInstance().stop();
+    this.logger.debug(timer);
+
+    return { assessResults: allAssessResults };
   }
 }

--- a/src/migration/dataraptor.ts
+++ b/src/migration/dataraptor.ts
@@ -5,259 +5,286 @@ import DRMapItemMappings from '../mappings/DRMapItem';
 import { DebugTimer, QueryTools } from '../utils';
 import { NetUtils } from '../utils/net';
 import { BaseMigrationTool } from './base';
-import { MigrationResult, MigrationTool, ObjectMapping, TransformData, UploadRecordResult } from './interfaces';
-
+import {
+  AssessResult,
+  MigrationResult,
+  MigrationTool,
+  ObjectMapping,
+  TransformData,
+  UploadRecordResult,
+} from './interfaces';
 
 export class DataRaptorMigrationTool extends BaseMigrationTool implements MigrationTool {
+  static readonly DRBUNDLE_NAME = 'DRBundle__c';
+  static readonly DRMAPITEM_NAME = 'DRMapItem__c';
 
-	static readonly DRBUNDLE_NAME = 'DRBundle__c';
-	static readonly DRMAPITEM_NAME = 'DRMapItem__c';
+  static readonly OMNIDATATRANSFORM_NAME = 'OmniDataTransform';
+  static readonly OMNIDATATRANSFORMITEM_NAME = 'OmniDataTransformItem';
 
-	static readonly OMNIDATATRANSFORM_NAME = 'OmniDataTransform';
-	static readonly OMNIDATATRANSFORMITEM_NAME = 'OmniDataTransformItem';
+  getName(): string {
+    return 'DataRaptor';
+  }
 
-	getName(): string {
-		return "DataRaptor";
-	}
+  getRecordName(record: string) {
+    return record['Name'];
+  }
 
-	getRecordName(record: string) {
-		return record['Name'];
-	}
+  getMappings(): ObjectMapping[] {
+    return [
+      {
+        source: DataRaptorMigrationTool.DRBUNDLE_NAME,
+        target: DataRaptorMigrationTool.OMNIDATATRANSFORM_NAME,
+      },
+      {
+        source: DataRaptorMigrationTool.DRMAPITEM_NAME,
+        target: DataRaptorMigrationTool.OMNIDATATRANSFORMITEM_NAME,
+      },
+    ];
+  }
 
-	getMappings(): ObjectMapping[] {
-		return [{
-			source: DataRaptorMigrationTool.DRBUNDLE_NAME,
-			target: DataRaptorMigrationTool.OMNIDATATRANSFORM_NAME
-		}, {
-			source: DataRaptorMigrationTool.DRMAPITEM_NAME,
-			target: DataRaptorMigrationTool.OMNIDATATRANSFORMITEM_NAME
-		}];
-	}
+  async assess(): Promise<AssessResult[]> {
+    return [];
+  }
 
-	async truncate(): Promise<void> {
-		await super.truncate(DataRaptorMigrationTool.OMNIDATATRANSFORM_NAME)
-	}
+  async truncate(): Promise<void> {
+    await super.truncate(DataRaptorMigrationTool.OMNIDATATRANSFORM_NAME);
+  }
 
-	async migrate(): Promise<MigrationResult[]> {
-		return [await this.MigrateDataRaptorData()];
-	}
+  async migrate(): Promise<MigrationResult[]> {
+    return [await this.MigrateDataRaptorData()];
+  }
 
-	private async MigrateDataRaptorData(): Promise<MigrationResult> {
-		let originalDrRecords = new Map<string, any>();
-		let drUploadInfo = new Map<string, UploadRecordResult>();
-		const duplicatedNames = new Set<string>();
+  private async MigrateDataRaptorData(): Promise<MigrationResult> {
+    let originalDrRecords = new Map<string, any>();
+    let drUploadInfo = new Map<string, UploadRecordResult>();
+    const duplicatedNames = new Set<string>();
 
-		// Query all dataraptors and the respective items
-		DebugTimer.getInstance().lap('Query data raptors');
-		const dataRaptors = await this.getAllDataRaptors();
-		const dataRaptorItemsData = await this.getAllItems();
+    // Query all dataraptors and the respective items
+    DebugTimer.getInstance().lap('Query data raptors');
+    const dataRaptors = await this.getAllDataRaptors();
+    const dataRaptorItemsData = await this.getAllItems();
 
-		// Start transforming each dataRaptor
-		DebugTimer.getInstance().lap('Transform Data Raptor');
-		let done = 0;
-		const total = dataRaptors.length;
+    // Start transforming each dataRaptor
+    DebugTimer.getInstance().lap('Transform Data Raptor');
+    let done = 0;
+    const total = dataRaptors.length;
 
-		for (let dr of dataRaptors) {
-			this.reportProgress(total, done);
+    for (let dr of dataRaptors) {
+      this.reportProgress(total, done);
 
-			// Skip if Type is "Migration"
-			if (dr[this.namespacePrefix + 'Type__c'] === 'Migration') continue;
-			const recordId = dr['Id'];
-			const name = dr['Name'];
+      // Skip if Type is "Migration"
+      if (dr[this.namespacePrefix + 'Type__c'] === 'Migration') continue;
+      const recordId = dr['Id'];
+      const name = dr['Name'];
 
-			const typeKey = dr[this.namespacePrefix + 'Type__c'];
-			const outputTypeKey = dr[this.namespacePrefix + 'OutputType__c'];
-			const targetOutputDocumentIdentifier = dr[this.namespacePrefix + 'TargetOutDocuSignTemplateId__c'];
-			const targetOutputFileName = dr[this.namespacePrefix + 'TargetOutPdfDocName__c'];
+      const typeKey = dr[this.namespacePrefix + 'Type__c'];
+      const outputTypeKey = dr[this.namespacePrefix + 'OutputType__c'];
+      const targetOutputDocumentIdentifier = dr[this.namespacePrefix + 'TargetOutDocuSignTemplateId__c'];
+      const targetOutputFileName = dr[this.namespacePrefix + 'TargetOutPdfDocName__c'];
 
-			if (typeKey === null) {
-				dr[this.namespacePrefix + 'Type__c'] = 'Extract';
-			}
+      if (typeKey === null) {
+        dr[this.namespacePrefix + 'Type__c'] = 'Extract';
+      }
 
-			// Fix up Input/Output types for older DR's
-			switch (typeKey) {
-				case 'Transform':
-					dr[this.namespacePrefix + 'Type__c'] = 'Transform';
-					dr[this.namespacePrefix + 'InputType__c'] = 'JSON';
-					if (targetOutputDocumentIdentifier !== null) {
-						dr[this.namespacePrefix + 'OutputType__c'] = 'DocuSign';
-					} else if (targetOutputFileName !== null &&
-						(outputTypeKey !== 'PDF' || outputTypeKey !== 'Document Template')) {
-						dr[this.namespacePrefix + 'OutputType__c'] = 'PDF';
-					} else {
-						dr[this.namespacePrefix + 'OutputType__c'] = 'JSON';
-					}
-					break;
-				case 'Extract (JSON)':
-					dr[this.namespacePrefix + 'Type__c'] = 'Extract';
-					dr[this.namespacePrefix + 'InputType__c'] = 'JSON';
-					dr[this.namespacePrefix + 'OutputType__c'] = 'JSON';
-					break;
-				case 'Load (JSON)':
-					dr[this.namespacePrefix + 'Type__c'] = 'Load';
-					dr[this.namespacePrefix + 'InputType__c'] = 'JSON';
-					dr[this.namespacePrefix + 'OutputType__c'] = 'SObject';
-					break;
-				case 'Load (Object)':
-					dr[this.namespacePrefix + 'Type__c'] = 'Load';
-					dr[this.namespacePrefix + 'InputType__c'] = 'SObject';
-					dr[this.namespacePrefix + 'OutputType__c'] = 'SObject';
-					break;
-				default: // no-op;
-			}
+      // Fix up Input/Output types for older DR's
+      switch (typeKey) {
+        case 'Transform':
+          dr[this.namespacePrefix + 'Type__c'] = 'Transform';
+          dr[this.namespacePrefix + 'InputType__c'] = 'JSON';
+          if (targetOutputDocumentIdentifier !== null) {
+            dr[this.namespacePrefix + 'OutputType__c'] = 'DocuSign';
+          } else if (
+            targetOutputFileName !== null &&
+            (outputTypeKey !== 'PDF' || outputTypeKey !== 'Document Template')
+          ) {
+            dr[this.namespacePrefix + 'OutputType__c'] = 'PDF';
+          } else {
+            dr[this.namespacePrefix + 'OutputType__c'] = 'JSON';
+          }
+          break;
+        case 'Extract (JSON)':
+          dr[this.namespacePrefix + 'Type__c'] = 'Extract';
+          dr[this.namespacePrefix + 'InputType__c'] = 'JSON';
+          dr[this.namespacePrefix + 'OutputType__c'] = 'JSON';
+          break;
+        case 'Load (JSON)':
+          dr[this.namespacePrefix + 'Type__c'] = 'Load';
+          dr[this.namespacePrefix + 'InputType__c'] = 'JSON';
+          dr[this.namespacePrefix + 'OutputType__c'] = 'SObject';
+          break;
+        case 'Load (Object)':
+          dr[this.namespacePrefix + 'Type__c'] = 'Load';
+          dr[this.namespacePrefix + 'InputType__c'] = 'SObject';
+          dr[this.namespacePrefix + 'OutputType__c'] = 'SObject';
+          break;
+        default: // no-op;
+      }
 
-			// Transform the data raptor
-			const transformedDataRaptor = this.mapDataRaptorRecord(dr);
+      // Transform the data raptor
+      const transformedDataRaptor = this.mapDataRaptorRecord(dr);
 
-			// Verify duplicated names before trying to submitt
-			if (duplicatedNames.has(transformedDataRaptor['Name'])) {
-				this.setRecordErrors(dr, this.messages.getMessage('duplicatedDrName'));
-				originalDrRecords.set(recordId, dr);
-				continue;
-			}
-			duplicatedNames.add(transformedDataRaptor['Name']);
+      // Verify duplicated names before trying to submitt
+      if (duplicatedNames.has(transformedDataRaptor['Name'])) {
+        this.setRecordErrors(dr, this.messages.getMessage('duplicatedDrName'));
+        originalDrRecords.set(recordId, dr);
+        continue;
+      }
+      duplicatedNames.add(transformedDataRaptor['Name']);
 
-			// Create a map of the original records
-			originalDrRecords.set(recordId, dr);
+      // Create a map of the original records
+      originalDrRecords.set(recordId, dr);
 
-			// Save the data raptors
-			// const drUploadResponse = await this.uploadTransformedData(DataRaptorMigrationTool.OMNIDATATRANSFORM_NAME, { mappedRecords, originalRecords });
-			const drUploadResponse = await NetUtils.createOne(this.connection, DataRaptorMigrationTool.OMNIDATATRANSFORM_NAME, recordId, transformedDataRaptor);
+      // Save the data raptors
+      // const drUploadResponse = await this.uploadTransformedData(DataRaptorMigrationTool.OMNIDATATRANSFORM_NAME, { mappedRecords, originalRecords });
+      const drUploadResponse = await NetUtils.createOne(
+        this.connection,
+        DataRaptorMigrationTool.OMNIDATATRANSFORM_NAME,
+        recordId,
+        transformedDataRaptor
+      );
 
-			if (drUploadResponse && drUploadResponse.success === true) {
-				const items = await this.getItemsForDataRaptor(dataRaptorItemsData, name, drUploadResponse.id);
+      if (drUploadResponse && drUploadResponse.success === true) {
+        const items = await this.getItemsForDataRaptor(dataRaptorItemsData, name, drUploadResponse.id);
 
-				// Check for name changes
-				if (transformedDataRaptor[DRBundleMappings.Name] !== dr['Name']) {
-					drUploadResponse.newName = transformedDataRaptor[DRBundleMappings.Name];
-				}
+        // Check for name changes
+        if (transformedDataRaptor[DRBundleMappings.Name] !== dr['Name']) {
+          drUploadResponse.newName = transformedDataRaptor[DRBundleMappings.Name];
+        }
 
-				// Move the items
-				await this.uploadTransformedData(DataRaptorMigrationTool.OMNIDATATRANSFORMITEM_NAME, items);
+        // Move the items
+        await this.uploadTransformedData(DataRaptorMigrationTool.OMNIDATATRANSFORMITEM_NAME, items);
 
-				drUploadInfo.set(recordId, drUploadResponse);
-			}
+        drUploadInfo.set(recordId, drUploadResponse);
+      }
 
-			done++;
-		};
+      done++;
+    }
 
-		return {
-			name: 'Data Raptor',
-			results: drUploadInfo,
-			records: originalDrRecords
-		};
-	}
+    return {
+      name: 'Data Raptor',
+      results: drUploadInfo,
+      records: originalDrRecords,
+    };
+  }
 
+  // Get All DRBundle__c records
+  private async getAllDataRaptors(): Promise<AnyJson[]> {
+    DebugTimer.getInstance().lap('Query DRBundle');
+    return await QueryTools.queryAll(
+      this.connection,
+      this.namespace,
+      DataRaptorMigrationTool.DRBUNDLE_NAME,
+      this.getDRBundleFields()
+    );
+  }
 
-	// Get All DRBundle__c records 
-	private async getAllDataRaptors(): Promise<AnyJson[]> {
-		DebugTimer.getInstance().lap('Query DRBundle');
-		return await QueryTools.queryAll(this.connection, this.namespace, DataRaptorMigrationTool.DRBUNDLE_NAME, this.getDRBundleFields());
-	}
+  // Get All Items
+  private async getAllItems(): Promise<AnyJson[]> {
+    //Query all Elements
+    return await QueryTools.queryAll(
+      this.connection,
+      this.namespace,
+      DataRaptorMigrationTool.DRMAPITEM_NAME,
+      this.getDRMapItemFields()
+    );
+  }
 
+  // Get All Items for one DataRaptor
+  private async getItemsForDataRaptor(
+    dataRaptorItems: AnyJson[],
+    drName: string,
+    drId: string
+  ): Promise<TransformData> {
+    //Query all Elements
+    const mappedRecords = [],
+      originalRecords = new Map<string, AnyJson>();
 
-	// Get All Items
-	private async getAllItems(): Promise<AnyJson[]> {
-		//Query all Elements
-		return await QueryTools.queryAll(this.connection, this.namespace, DataRaptorMigrationTool.DRMAPITEM_NAME, this.getDRMapItemFields());
-	}
+    dataRaptorItems.forEach((drItem) => {
+      const recordId = drItem['Id'];
+      // const itemParentId = drItem[nsPrefix + 'OmniDataTransformationId__c']
+      if (drItem['Name'] === drName) {
+        mappedRecords.push(this.mapDataRaptorItemData(drItem, drId));
+      }
 
+      // Create a map of the original records
+      originalRecords.set(recordId, drItem);
+    });
 
-	// Get All Items for one DataRaptor
-	private async getItemsForDataRaptor(dataRaptorItems: AnyJson[], drName: string, drId: string): Promise<TransformData> {
-		//Query all Elements
-		const mappedRecords = [],
-			originalRecords = new Map<string, AnyJson>();
+    return { originalRecords, mappedRecords };
+  }
 
-		dataRaptorItems.forEach(drItem => {
+  /**
+   * Maps an indivitdual DRBundle__c record to an OmniDataTransform record.
+   * @param dataRaptorRecord
+   * @returns
+   */
+  private mapDataRaptorRecord(dataRaptorRecord: AnyJson): AnyJson {
+    // Transformed object
+    const mappedObject = {};
 
-			const recordId = drItem['Id'];
-			// const itemParentId = drItem[nsPrefix + 'OmniDataTransformationId__c']
-			if (drItem['Name'] === drName) {
-				mappedRecords.push(this.mapDataRaptorItemData(drItem, drId));
-			}
+    // Get the fields of the record
+    const recordFields = Object.keys(dataRaptorRecord);
 
-			// Create a map of the original records
-			originalRecords.set(recordId, drItem);
-		});
+    // Map individual fields
+    recordFields.forEach((recordField) => {
+      const cleanFieldName = this.getCleanFieldName(recordField);
 
-		return { originalRecords, mappedRecords };
-	}
+      if (DRBundleMappings.hasOwnProperty(cleanFieldName)) {
+        mappedObject[DRBundleMappings[cleanFieldName]] = dataRaptorRecord[recordField];
+      }
+    });
 
-	/**
-	 * Maps an indivitdual DRBundle__c record to an OmniDataTransform record.
-	 * @param dataRaptorRecord 
-	 * @returns 
-	 */
-	private mapDataRaptorRecord(dataRaptorRecord: AnyJson): AnyJson {
+    mappedObject['Name'] = this.cleanName(mappedObject['Name']);
+    mappedObject['IsActive'] = true;
 
-		// Transformed object
-		const mappedObject = {};
+    // BATCH framework requires that each record has an "attributes" property
+    mappedObject['attributes'] = {
+      type: DataRaptorMigrationTool.OMNIDATATRANSFORM_NAME,
+      referenceId: dataRaptorRecord['Id'],
+    };
 
-		// Get the fields of the record
-		const recordFields = Object.keys(dataRaptorRecord);
+    return mappedObject;
+  }
 
-		// Map individual fields
-		recordFields.forEach(recordField => {
-			const cleanFieldName = this.getCleanFieldName(recordField);
+  /**
+   * Maps an individual DRMapItem__c into an OmniDataTransformId record
+   * @param dataRaptorItemRecord
+   * @returns
+   */
+  private mapDataRaptorItemData(dataRaptorItemRecord: AnyJson, omniDataTransformationId: string) {
+    // Transformed object
+    const mappedObject = {};
 
-			if (DRBundleMappings.hasOwnProperty(cleanFieldName)) {
-				mappedObject[DRBundleMappings[cleanFieldName]] = dataRaptorRecord[recordField];
-			}
-		});
+    // Get the fields of the record
+    const recordFields = Object.keys(dataRaptorItemRecord);
 
-		mappedObject['Name'] = this.cleanName(mappedObject['Name']);
-		mappedObject['IsActive'] = true;
+    // Map individual fields
+    recordFields.forEach((recordField) => {
+      const cleanFieldName = this.getCleanFieldName(recordField);
 
-		// BATCH framework requires that each record has an "attributes" property
-		mappedObject['attributes'] = {
-			type: DataRaptorMigrationTool.OMNIDATATRANSFORM_NAME,
-			referenceId: dataRaptorRecord['Id']
-		};
+      if (DRMapItemMappings.hasOwnProperty(cleanFieldName)) {
+        mappedObject[DRMapItemMappings[cleanFieldName]] = dataRaptorItemRecord[recordField];
+      }
+    });
 
-		return mappedObject;
-	}
+    // Set the parent/child relationship
+    mappedObject['OmniDataTransformationId'] = omniDataTransformationId;
+    mappedObject['Name'] = this.cleanName(mappedObject['Name']);
 
-	/**
-	 * Maps an individual DRMapItem__c into an OmniDataTransformId record
-	 * @param dataRaptorItemRecord 
-	 * @returns 
-	 */
-	private mapDataRaptorItemData(dataRaptorItemRecord: AnyJson, omniDataTransformationId: string) {
-		// Transformed object
-		const mappedObject = {};
+    // BATCH framework requires that each record has an "attributes" property
+    mappedObject['attributes'] = {
+      type: DataRaptorMigrationTool.OMNIDATATRANSFORMITEM_NAME,
+      referenceId: dataRaptorItemRecord['Id'],
+    };
 
-		// Get the fields of the record
-		const recordFields = Object.keys(dataRaptorItemRecord);
+    return mappedObject;
+  }
 
-		// Map individual fields
-		recordFields.forEach(recordField => {
-			const cleanFieldName = this.getCleanFieldName(recordField);
+  private getDRBundleFields(): string[] {
+    return Object.keys(DRBundleMappings);
+  }
 
-			if (DRMapItemMappings.hasOwnProperty(cleanFieldName)) {
-				mappedObject[DRMapItemMappings[cleanFieldName]] = dataRaptorItemRecord[recordField];
-			}
-		});
-
-		// Set the parent/child relationship
-		mappedObject['OmniDataTransformationId'] = omniDataTransformationId;
-		mappedObject['Name'] = this.cleanName(mappedObject['Name']);
-
-		// BATCH framework requires that each record has an "attributes" property
-		mappedObject['attributes'] = {
-			type: DataRaptorMigrationTool.OMNIDATATRANSFORMITEM_NAME,
-			referenceId: dataRaptorItemRecord['Id']
-		};
-
-		return mappedObject;
-	}
-
-	private getDRBundleFields(): string[] {
-		return Object.keys(DRBundleMappings);
-	}
-
-	private getDRMapItemFields(): string[] {
-		return Object.keys(DRMapItemMappings);
-	}
-
+  private getDRMapItemFields(): string[] {
+    return Object.keys(DRMapItemMappings);
+  }
 }

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -4,7 +4,7 @@ import CardMappings from '../mappings/VlocityCard';
 import { DebugTimer, QueryTools, SortDirection } from '../utils';
 import { NetUtils } from '../utils/net';
 import { BaseMigrationTool } from './base';
-import { MigrationResult, MigrationTool, ObjectMapping, UploadRecordResult } from './interfaces';
+import { AssessResult, MigrationResult, MigrationTool, ObjectMapping, UploadRecordResult } from './interfaces';
 import { Connection, Logger, Messages } from '@salesforce/core';
 import { UX } from '@salesforce/command';
 
@@ -72,8 +72,11 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
     // Get All the Active VlocityCard__c records
     const cards = await this.getAllActiveCards();
 
+    // Build LWC classification map once for the whole migration run
+    const lwcMap = await this.getLwcClassifications();
+
     // Save the Vlocity Cards in OmniUiCard
-    const cardUploadResponse = await this.uploadAllCards(cards);
+    const cardUploadResponse = await this.uploadAllCards(cards, lwcMap);
 
     const records = new Map<string, any>();
     for (let i = 0; i < cards.length; i++) {
@@ -89,8 +92,94 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
     ];
   }
 
+  // Assess cards for cross-namespace LWC reference risks
+  async assess(): Promise<AssessResult[]> {
+    const lwcMap = await this.getLwcClassifications();
+    const cards = await this.getAllActiveCards();
+    const results: AssessResult[] = [];
+
+    for (const card of cards) {
+      const warnings = this.detectCustomLwcEmbeds(card, lwcMap);
+      if (warnings.length > 0) {
+        results.push({
+          name: card['Name'],
+          componentType: 'FlexCard',
+          warnings,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  // Query LightningComponentBundle via Tooling API and classify each unmanaged LWC
+  private async getLwcClassifications(): Promise<Map<string, string>> {
+    const lwcMap = new Map<string, string>();
+    try {
+      const result = await (this.connection as any).tooling.query(
+        'SELECT Id, DeveloperName, NamespacePrefix FROM LightningComponentBundle'
+      );
+      for (const record of result.records || []) {
+        const name: string = record['DeveloperName'] || '';
+        const ns: string = record['NamespacePrefix'] || '';
+        if (ns) continue; // managed package — skip
+        let kind: string;
+        if (/^cf[a-z0-9]/i.test(name)) {
+          kind = 'generated-fc';
+        } else if (/^[a-z0-9]+_[a-z0-9]+_[a-z0-9]+$/i.test(name)) {
+          kind = 'generated-os';
+        } else {
+          kind = 'custom';
+        }
+        lwcMap.set(name.toLowerCase(), kind);
+      }
+    } catch (e) {
+      this.logger.warn('Could not query LightningComponentBundle: ' + e);
+    }
+    return lwcMap;
+  }
+
+  // Walk a card's Definition__c JSON and collect cross-namespace LWC embed warnings
+  private detectCustomLwcEmbeds(card: AnyJson, lwcMap: Map<string, string>): string[] {
+    const warnings: string[] = [];
+    let definition: any;
+    try {
+      definition = JSON.parse(card[this.namespacePrefix + 'Definition__c'] || '{}');
+    } catch {
+      return warnings;
+    }
+
+    const walkChildren = (children: any[]) => {
+      for (const child of children || []) {
+        if (child.element === 'customLwc') {
+          const lwcName: string = (child.property?.customlwcname || '').toLowerCase();
+          if (lwcName && lwcMap.has(lwcName)) {
+            warnings.push(
+              `Embeds LWC '${child.property.customlwcname}' (${lwcMap.get(lwcName)}). ` +
+                `After migration the auto-generated FlexCard LWC retains the vertical namespace while this LWC ` +
+                `moves to c/ — cross-reference error at runtime. Workaround: use omnistudio-standard-runtime-wrapper.`
+            );
+          }
+        }
+        if (child.children && Array.isArray(child.children)) {
+          walkChildren(child.children);
+        }
+      }
+    };
+
+    for (const state of definition.states || []) {
+      for (const componentKey in state.components || {}) {
+        if (state.components.hasOwnProperty(componentKey)) {
+          walkChildren(state.components[componentKey].children || []);
+        }
+      }
+    }
+
+    return warnings;
+  }
+
   // Query all cards that are active
-  private async getAllActiveCards(): Promise<AnyJson[]> {
+  protected async getAllActiveCards(): Promise<AnyJson[]> {
     DebugTimer.getInstance().lap('Query Vlocity Cards');
     const filters = new Map<string, any>();
     filters.set(this.namespacePrefix + 'CardType__c', 'flex');
@@ -121,13 +210,13 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
   }
 
   // Upload All the VlocityCard__c records to OmniUiCard
-  private async uploadAllCards(cards: any[]): Promise<Map<string, UploadRecordResult>> {
+  private async uploadAllCards(cards: any[], lwcMap: Map<string, string>): Promise<Map<string, UploadRecordResult>> {
     const cardsUploadInfo = new Map<string, UploadRecordResult>();
     const originalRecords = new Map<string, any>();
     const uniqueNames = new Set<string>();
 
     for (let card of cards) {
-      await this.uploadCard(cards, card, cardsUploadInfo, originalRecords, uniqueNames);
+      await this.uploadCard(cards, card, cardsUploadInfo, originalRecords, uniqueNames, lwcMap);
     }
 
     return cardsUploadInfo;
@@ -138,7 +227,8 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
     card: AnyJson,
     cardsUploadInfo: Map<string, UploadRecordResult>,
     originalRecords: Map<string, any>,
-    uniqueNames: Set<string>
+    uniqueNames: Set<string>,
+    lwcMap: Map<string, string>
   ) {
     const recordId = card['Id'];
 
@@ -155,7 +245,7 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
           // Upload child cards
           const childCard = allCards.find((c) => c['Name'] === childCardName);
           if (childCard) {
-            await this.uploadCard(allCards, childCard, cardsUploadInfo, originalRecords, uniqueNames);
+            await this.uploadCard(allCards, childCard, cardsUploadInfo, originalRecords, uniqueNames, lwcMap);
           }
         }
 
@@ -224,6 +314,10 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
             .join(', ');
           uploadResult.errors.push('Integration Procedure Actions will need manual updates, please verify: ' + val);
         }
+
+        // Append cross-namespace LWC warnings
+        const lwcWarnings = this.detectCustomLwcEmbeds(card, lwcMap);
+        uploadResult.warnings.push(...lwcWarnings);
 
         cardsUploadInfo.set(recordId, uploadResult);
 

--- a/src/migration/interfaces.ts
+++ b/src/migration/interfaces.ts
@@ -8,6 +8,11 @@ export interface MigrationTool {
   migrate(): Promise<MigrationResult[]>;
 
   /**
+   * Assesses components for cross-namespace LWC reference risks without migrating
+   */
+  assess(): Promise<AssessResult[]>;
+
+  /**
    * Gets the list of source-target objects that the tool will migrate
    */
   getMappings(): ObjectMapping[];
@@ -28,6 +33,12 @@ export interface MigrationTool {
    * Truncates the standard objects.
    */
   truncate(): Promise<void>;
+}
+
+export interface AssessResult {
+  name: string;
+  componentType: string;
+  warnings: string[];
 }
 
 export interface ObjectMapping {

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -6,7 +6,7 @@ import ElementMappings from '../mappings/Element';
 import OmniScriptDefinitionMappings from '../mappings/OmniScriptDefinition';
 import { DebugTimer, QueryTools, SortDirection } from '../utils';
 import { BaseMigrationTool } from './base';
-import { MigrationResult, MigrationTool, TransformData, UploadRecordResult } from './interfaces';
+import { AssessResult, MigrationResult, MigrationTool, TransformData, UploadRecordResult } from './interfaces';
 import { ObjectMapping } from './interfaces';
 import { NetUtils, RequestMethod } from '../utils/net';
 import { Connection, Logger, Messages } from '@salesforce/core';
@@ -160,10 +160,90 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     };
   }
 
+  // Assess OmniScripts for cross-namespace LWC reference risks
+  async assess(): Promise<AssessResult[]> {
+    const lwcMap = await this.getLwcClassifications();
+    const omniscripts = await this.getAllOmniScripts();
+    const results: AssessResult[] = [];
+
+    for (const omniscript of omniscripts) {
+      const recordId = omniscript['Id'];
+      const elements = await this.getAllElementsForOmniScript(recordId);
+      const warnings: string[] = [];
+
+      for (const element of elements) {
+        const elementType: string = element[`${this.namespacePrefix}Type__c`] || '';
+        if (elementType !== 'Custom Lightning Web Component') continue;
+
+        let propertySet: any = {};
+        try {
+          propertySet = JSON.parse(element[`${this.namespacePrefix}PropertySet__c`] || '{}');
+        } catch {
+          /* skip unparseable */
+        }
+
+        const lwcName: string = propertySet['lwcName'] || '';
+        if (!lwcName) continue;
+
+        const kind = lwcMap.get(lwcName.toLowerCase());
+        if (kind !== undefined) {
+          warnings.push(
+            `Element '${element['Name']}' embeds LWC '${lwcName}' (${kind}). ` +
+              `After migration the auto-generated OmniScript LWC retains the vertical namespace while this LWC ` +
+              `moves to c/ — cross-reference error at runtime. Workaround: use omnistudio-standard-runtime-wrapper.`
+          );
+        }
+      }
+
+      if (warnings.length > 0) {
+        const osName =
+          omniscript[`${this.namespacePrefix}Type__c`] +
+          '_' +
+          omniscript[`${this.namespacePrefix}SubType__c`] +
+          (omniscript[`${this.namespacePrefix}Language__c`]
+            ? '_' + omniscript[`${this.namespacePrefix}Language__c`]
+            : '');
+        results.push({ name: osName, componentType: 'OmniScript', warnings });
+      }
+    }
+
+    return results;
+  }
+
+  // Query LightningComponentBundle via Tooling API and classify each unmanaged LWC
+  private async getLwcClassifications(): Promise<Map<string, string>> {
+    const lwcMap = new Map<string, string>();
+    try {
+      const result = await (this.connection as any).tooling.query(
+        'SELECT Id, DeveloperName, NamespacePrefix FROM LightningComponentBundle'
+      );
+      for (const record of result.records || []) {
+        const name: string = record['DeveloperName'] || '';
+        const ns: string = record['NamespacePrefix'] || '';
+        if (ns) continue;
+        let kind: string;
+        if (/^cf[a-z0-9]/i.test(name)) {
+          kind = 'generated-fc';
+        } else if (/^[a-z0-9]+_[a-z0-9]+_[a-z0-9]+$/i.test(name)) {
+          kind = 'generated-os';
+        } else {
+          kind = 'custom';
+        }
+        lwcMap.set(name.toLowerCase(), kind);
+      }
+    } catch (e) {
+      this.logger.warn('Could not query LightningComponentBundle: ' + e);
+    }
+    return lwcMap;
+  }
+
   async migrate(): Promise<MigrationResult[]> {
     // Get All Records from OmniScript__c (IP & OS Parent Records)
     const omniscripts = await this.getAllOmniScripts();
     const duplicatedNames = new Set<string>();
+
+    // Build LWC classification map once for the whole migration run
+    const lwcMap = await this.getLwcClassifications();
 
     // Variables to be returned After Migration
     let done = 0;
@@ -262,7 +342,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
 
         try {
           // Upload All elements for each OmniScript__c record(i.e IP/OS)
-          await this.uploadAllElements(osUploadResponse, elements);
+          await this.uploadAllElements(osUploadResponse, elements, lwcMap);
 
           // Get OmniScript Compiled Definitions for OmniScript Record
           const omniscriptsCompiledDefinitions = await this.getOmniScriptCompiledDefinition(recordId);
@@ -443,7 +523,8 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
   // Upload All the Elements tagged to a OmniScript__c record, after the parent record has been inserted
   private async uploadAllElements(
     omniScriptUploadResults: UploadRecordResult,
-    elements: AnyJson[]
+    elements: AnyJson[],
+    lwcMap: Map<string, string>
   ): Promise<Map<string, UploadRecordResult>> {
     let levelCount = 0; // To define and insert different levels(Parent-Child relationship) at a time
     let exit = false; // Counter variable to exit after all parent-child elements inserted
@@ -472,7 +553,8 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
         let elementsTransformedData = await this.prepareElementsData(
           omniScriptUploadResults,
           tempElements,
-          elementsUploadInfo
+          elementsUploadInfo,
+          lwcMap
         );
         // Upload the transformed Element__c
         let elementsUploadResponse = await this.uploadTransformedData(
@@ -505,7 +587,8 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
   private async prepareElementsData(
     osUploadResult: UploadRecordResult,
     elements: AnyJson[],
-    parentElementUploadResponse: Map<string, UploadRecordResult>
+    parentElementUploadResponse: Map<string, UploadRecordResult>,
+    lwcMap: Map<string, string>
   ): Promise<TransformData> {
     const mappedRecords = [],
       originalRecords = new Map<string, AnyJson>(),
@@ -521,6 +604,27 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
 
       // Create a map of the original records
       originalRecords.set(element['Id'], element);
+
+      // Check for cross-namespace LWC embeds and attach warnings
+      const elementType: string = element[`${this.namespacePrefix}Type__c`] || '';
+      if (elementType === 'Custom Lightning Web Component') {
+        let propertySet: any = {};
+        try {
+          propertySet = JSON.parse(element[`${this.namespacePrefix}PropertySet__c`] || '{}');
+        } catch {
+          /* skip unparseable */
+        }
+        const lwcName: string = propertySet['lwcName'] || '';
+        const kind = lwcName ? lwcMap.get(lwcName.toLowerCase()) : undefined;
+        if (kind !== undefined) {
+          osUploadResult.warnings = osUploadResult.warnings || [];
+          osUploadResult.warnings.push(
+            `Element '${element['Name']}' embeds LWC '${lwcName}' (${kind}). ` +
+              `After migration the auto-generated OmniScript LWC retains the vertical namespace while this LWC ` +
+              `moves to c/ — cross-reference error at runtime. Workaround: use omnistudio-standard-runtime-wrapper.`
+          );
+        }
+      }
     });
 
     if (osUploadResult.id && invalidIpNames.size > 0) {


### PR DESCRIPTION
Assess Mode:
<img width="3456" height="2098" alt="image" src="https://github.com/user-attachments/assets/de24c668-9081-473b-985a-51fff1f40015" />

Migration Mode:
<img width="3444" height="2106" alt="image" src="https://github.com/user-attachments/assets/9a636eac-06ca-4d5b-8f82-c464a7f0914c" />


### What does this PR do?
**The workflow before my changes:**
`sf omnistudio migration migrate -u <org> -n vlocity_ins`
The info command was literally unused placeholder code that shipped with the initial repo scaffolding. Nobody was using it — it just printed "Hello world" and had no OmniStudio functionality.
The real tool had:
migrate— the actual migration command (fully implemented)
info— placeholder, never used in production

My changes repurposed info into a useful pre-migration assessment command  which gives users a way to detect cross-namespace LWC issues before running migrate.
**Workflow after my changes**
**Before migration**:
`sf omnistudio migration info -u <org> -n vlocity_ins`
This is read-only — detects which FlexCards/OmniScripts embed custom LWCs that will cause cross-namespace errors after migration. User can review the warnings and apply the workaround (use omnistudio-standard-runtime-wrapper) before migrating.
**Then migrate:**
`sf omnistudio migration migrate -u <org> -n vlocity_ins`
This does the actual migration AND surfaces the same warnings in the HTML report for any affected components.
So the full workflow is:

Runinfo→ review warnings → fix affected components manually
Runmigrate→ migration happens, HTML report shows any remaining warnings

### What issues does this PR fix or reference?
@W-19835755@
