### PR TITLE
@W-19835755 - Detect custom LWC cross-namespace risks

### DIFF
--- a/messages/assess.json
+++ b/messages/assess.json
@@ -232,5 +232,6 @@
   "processingNotRequired": "Assessment is not required for orgs on standard data model with the Omnistudio Metadata setting turned on.",
   "skippingTruncation": "Skipping truncation as the org is on standard data model.",
   "loglevelFlagDeprecated": "loglevel is deprecated. Use --verbose instead",
-  "cleanupMetadataTablesRequired": "Omnistudio configuration tables contain records. Back up your Omnistudio component table data, and manually clean up the Omnistudio configuration tables. <a href='https://help.salesforce.com/s/articleView?id=xcloud.os_enable_omnistudio_metadata_api_support.htm&type=5' target='_blank'>Learn more about cleaning up tables in Salesforce Help</a>"
+  "cleanupMetadataTablesRequired": "Omnistudio configuration tables contain records. Back up your Omnistudio component table data, and manually clean up the Omnistudio configuration tables. <a href='https://help.salesforce.com/s/articleView?id=xcloud.os_enable_omnistudio_metadata_api_support.htm&type=5' target='_blank'>Learn more about cleaning up tables in Salesforce Help</a>",
+  "customLwcCrossNamespaceWarning": "Embeds LWC '%s' (%s). After migration the auto-generated %s LWC retains the vertical namespace while this LWC moves to c/ — cross-reference error at runtime. Workaround: use omnistudio-standard-runtime-wrapper or enable Lightning Web Security."
 }

--- a/messages/assess.json
+++ b/messages/assess.json
@@ -236,5 +236,5 @@
   "apexRemoteDatasourceNamespaceWarning": "ApexRemote datasource: remoteClass will be updated from \"%s\" to \"%s\"",
   "apexClassNotFound": "Apex class \"%s\" referenced in \"%s\" does not exist in the org",
   "cleanupMetadataTablesRequired": "Omnistudio configuration tables contain records. Back up your Omnistudio component table data, and manually clean up the Omnistudio configuration tables. <a href='https://help.salesforce.com/s/articleView?id=xcloud.os_enable_omnistudio_metadata_api_support.htm&type=5' target='_blank'>Learn more about cleaning up tables in Salesforce Help</a>",
-  "customLwcCrossNamespaceWarning": "Embeds LWC '%s' (%s). After migration the auto-generated %s LWC retains the vertical namespace while this LWC moves to c/ — cross-reference error at runtime. Workaround: use omnistudio-standard-runtime-wrapper or enable Lightning Web Security."
+  "customLwcCrossNamespaceWarning": "Embeds LWC '%s' (%s). After migration, the auto-generated %s LWC retains the vertical namespace while this LWC moves to c/, causing a cross-reference error at runtime. To resolve this, use the Omnistudio standard wrapper or enable Lightning Web Security."
 }

--- a/messages/migrate.json
+++ b/messages/migrate.json
@@ -338,5 +338,6 @@
   "preparingStorageForMetadataEnabledOrg": "Preparing storage for %s org on standard data model with the Omnistudio Metadata setting turned on.",
   "processingNotRequired": "Migration is not required for orgs on standard data model with the Omnistudio Metadata setting turned on.",
   "skippingTruncation": "Skipping truncation as the org is on standard data model.",
-  "loglevelFlagDeprecated": "loglevel is deprecated. Use --verbose instead."
+  "loglevelFlagDeprecated": "loglevel is deprecated. Use --verbose instead.",
+  "customLwcCrossNamespaceWarning": "Embeds LWC '%s' (%s). After migration the auto-generated %s LWC retains the vertical namespace while this LWC moves to c/ — cross-reference error at runtime. Workaround: use omnistudio-standard-runtime-wrapper or enable Lightning Web Security."
 }

--- a/messages/migrate.json
+++ b/messages/migrate.json
@@ -339,5 +339,5 @@
   "processingNotRequired": "Migration is not required for orgs on standard data model with the Omnistudio Metadata setting turned on.",
   "skippingTruncation": "Skipping truncation as the org is on standard data model.",
   "loglevelFlagDeprecated": "loglevel is deprecated. Use --verbose instead.",
-  "customLwcCrossNamespaceWarning": "Embeds LWC '%s' (%s). After migration the auto-generated %s LWC retains the vertical namespace while this LWC moves to c/ — cross-reference error at runtime. Workaround: use omnistudio-standard-runtime-wrapper or enable Lightning Web Security."
+  "customLwcCrossNamespaceWarning": "Embeds LWC '%s' (%s). After migration, the auto-generated %s LWC retains the vertical namespace while this LWC moves to c/, causing a cross-reference error at runtime. To resolve this, use the Omnistudio standard wrapper or enable Lightning Web Security."
 }

--- a/src/migration/base.ts
+++ b/src/migration/base.ts
@@ -5,7 +5,7 @@ import { DebugTimer, QueryTools } from '../utils';
 import { NetUtils } from '../utils/net';
 import { Stringutil } from '../utils/StringValue/stringutil';
 import { Logger } from '../utils/logger';
-import { TransformData, UploadRecordResult } from './interfaces';
+import { LwcBundleRecord, TransformData, UploadRecordResult } from './interfaces';
 import { NameMappingRegistry } from './NameMappingRegistry';
 
 export type ComponentType =
@@ -131,19 +131,16 @@ export class BaseMigrationTool {
   protected async getLwcClassifications(): Promise<Map<string, string>> {
     const lwcMap = new Map<string, string>();
     try {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       const result = await (
         this.connection as unknown as {
           tooling: {
-            query: (q: string) => Promise<{ records?: Array<{ DeveloperName?: string; NamespacePrefix?: string }> }>;
+            query: (q: string) => Promise<{ records?: LwcBundleRecord[] }>;
           };
         }
       ).tooling.query('SELECT Id, DeveloperName, NamespacePrefix FROM LightningComponentBundle');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+
       for (const record of result.records || []) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         const name: string = record.DeveloperName || '';
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         const ns: string = record.NamespacePrefix || '';
         if (ns) continue; // Skip managed packages
 

--- a/src/migration/base.ts
+++ b/src/migration/base.ts
@@ -118,4 +118,49 @@ export class BaseMigrationTool {
   protected setRecordErrors(record: unknown, ...errors: string[]): void {
     record['errors'] = errors;
   }
+
+  /**
+   * Queries Tooling API to classify unmanaged LWCs by naming pattern.
+   * Used to detect cross-namespace LWC references that will break after migration.
+   *
+   * @returns Map of LWC name (lowercase) to classification
+   * - 'generated-fc': FlexCard-generated LWC (pattern: cf*)
+   * - 'generated-os': OmniScript-generated LWC (pattern: *_*_*)
+   * - 'custom': User-defined custom LWC
+   */
+  protected async getLwcClassifications(): Promise<Map<string, string>> {
+    const lwcMap = new Map<string, string>();
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      const result = await (
+        this.connection as unknown as {
+          tooling: {
+            query: (q: string) => Promise<{ records?: Array<{ DeveloperName?: string; NamespacePrefix?: string }> }>;
+          };
+        }
+      ).tooling.query('SELECT Id, DeveloperName, NamespacePrefix FROM LightningComponentBundle');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      for (const record of result.records || []) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        const name: string = record.DeveloperName || '';
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        const ns: string = record.NamespacePrefix || '';
+        if (ns) continue; // Skip managed packages
+
+        let kind: string;
+        if (/^cf[a-z0-9]/i.test(name)) {
+          kind = 'generated-fc';
+        } else if (/^[a-z0-9]+_[a-z0-9]+_[a-z0-9]+$/i.test(name)) {
+          kind = 'generated-os';
+        } else {
+          kind = 'custom';
+        }
+        lwcMap.set(name.toLowerCase(), kind);
+      }
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e);
+      Logger.logVerbose(`Could not query LightningComponentBundle: ${error}`);
+    }
+    return lwcMap;
+  }
 }

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -1109,6 +1109,20 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
       // Create a map of the original records
       originalRecords.set(recordId, card);
 
+      // Block migration if cross-namespace LWC embeds detected (check BEFORE upload)
+      const lwcErrors = this.detectCustomLwcEmbeds(card, lwcMap);
+      if (lwcErrors.length > 0) {
+        const uploadResult: UploadRecordResult = {
+          referenceId: recordId,
+          hasErrors: true,
+          success: false,
+          errors: lwcErrors,
+          warnings: [],
+        };
+        cardsUploadInfo.set(recordId, uploadResult);
+        return;
+      }
+
       // Create card
 
       let uploadResult: UploadRecordResult;
@@ -1171,10 +1185,6 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
             .join(', ');
           uploadResult.errors.push(this.messages.getMessage('integrationProcedureManualUpdateMessage', [val]));
         }
-
-        // Detect cross-namespace LWC risks during migration
-        const lwcWarnings = this.detectCustomLwcEmbeds(card, lwcMap);
-        uploadResult.warnings.push(...lwcWarnings);
 
         cardsUploadInfo.set(recordId, uploadResult);
 

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -191,10 +191,13 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
     const uniqueNames = new Set<string>();
     const dupFlexCardNames: Map<string, string> = new Map<string, string>();
 
+    // Build LWC classification map once for all FlexCards
+    const lwcMap = await this.getLwcClassifications();
+
     // Now process each OmniScript and its elements
     for (const flexCard of flexCards) {
       try {
-        const flexCardAssessmentInfo = await this.processFlexCard(flexCard, uniqueNames, dupFlexCardNames);
+        const flexCardAssessmentInfo = await this.processFlexCard(flexCard, uniqueNames, dupFlexCardNames, lwcMap);
         flexCardAssessmentInfos.push(flexCardAssessmentInfo);
       } catch (e) {
         flexCardAssessmentInfos.push({
@@ -224,7 +227,8 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
   private async processFlexCard(
     flexCard: AnyJson,
     uniqueNames: Set<string>,
-    dupFlexCardNames: Map<string, string>
+    dupFlexCardNames: Map<string, string>,
+    lwcMap: Map<string, string>
   ): Promise<FlexCardAssessmentInfo> {
     const flexCardName = flexCard['Name'];
     Logger.info(this.messages.getMessage('processingFlexCard', [flexCardName]));
@@ -315,7 +319,6 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
     ];
 
     // Check for cross-namespace LWC embeds
-    const lwcMap = await this.getLwcClassifications();
     const lwcWarnings = this.detectCustomLwcEmbeds(flexCard, lwcMap);
     flexCardAssessmentInfo.warnings.push(...lwcWarnings);
     if (lwcWarnings.length > 0) {
@@ -597,9 +600,10 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
 
     const walkChildren = (children: any[]) => {
       for (const child of children || []) {
+        // Check for customLwc element
         if (child.element === 'customLwc') {
           const lwcName: string = (child.property?.customlwcname || '').toLowerCase();
-          if (lwcName && lwcMap.has(lwcName)) {
+          if (lwcName && lwcMap.has(lwcName) && lwcMap.get(lwcName) === 'custom') {
             warnings.push(
               this.messages.getMessage('customLwcCrossNamespaceWarning', [
                 child.property.customlwcname,
@@ -609,16 +613,50 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
             );
           }
         }
+
+        // Check for flyoutLwc in stateAction
+        if (child.property?.stateAction?.flyoutType === 'customLwc') {
+          const flyoutLwcName: string = (child.property.stateAction.flyoutLwc || '').toLowerCase();
+          if (flyoutLwcName && lwcMap.has(flyoutLwcName) && lwcMap.get(flyoutLwcName) === 'custom') {
+            warnings.push(
+              this.messages.getMessage('customLwcCrossNamespaceWarning', [
+                child.property.stateAction.flyoutLwc,
+                lwcMap.get(flyoutLwcName),
+                'FlexCard',
+              ])
+            );
+          }
+        }
+
         if (child.children && Array.isArray(child.children)) {
           walkChildren(child.children);
         }
       }
     };
 
+    // Check components in states
     for (const state of definition.states || []) {
       for (const componentKey in state.components || {}) {
         if (state.components.hasOwnProperty(componentKey)) {
           walkChildren(state.components[componentKey].children || []);
+        }
+      }
+    }
+
+    // Check events for flyoutLwc in actionList
+    for (const event of definition.events || []) {
+      for (const action of event.actionList || []) {
+        if (action.stateAction?.flyoutType === 'customLwc') {
+          const flyoutLwcName: string = (action.stateAction.flyoutLwc || '').toLowerCase();
+          if (flyoutLwcName && lwcMap.has(flyoutLwcName) && lwcMap.get(flyoutLwcName) === 'custom') {
+            warnings.push(
+              this.messages.getMessage('customLwcCrossNamespaceWarning', [
+                action.stateAction.flyoutLwc,
+                lwcMap.get(flyoutLwcName),
+                'FlexCard',
+              ])
+            );
+          }
         }
       }
     }

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -314,6 +314,15 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
       ...new Set(flexCardAssessmentInfo.dependenciesApexRemoteAction),
     ];
 
+    // Check for cross-namespace LWC embeds
+    const lwcMap = await this.getLwcClassifications();
+    const lwcWarnings = this.detectCustomLwcEmbeds(flexCard, lwcMap);
+    flexCardAssessmentInfo.warnings.push(...lwcWarnings);
+    if (lwcWarnings.length > 0) {
+      assessmentStatus = getUpdatedAssessmentStatus(assessmentStatus, 'Warnings');
+      flexCardAssessmentInfo.migrationStatus = assessmentStatus;
+    }
+
     return flexCardAssessmentInfo;
   }
 
@@ -566,6 +575,55 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
         // Note: Non-"cf" prefixed names are returned unchanged by the helper
       }
     }
+  }
+
+  /**
+   * Detects custom LWC embeds in FlexCard definition that will cause cross-namespace issues.
+   * After migration, auto-generated FlexCard LWCs retain the vertical namespace while
+   * embedded custom LWCs move to c/, causing cross-reference errors at runtime.
+   *
+   * @param card The FlexCard record
+   * @param lwcMap Classification map from getLwcClassifications()
+   * @returns Array of warning messages
+   */
+  private detectCustomLwcEmbeds(card: AnyJson, lwcMap: Map<string, string>): string[] {
+    const warnings: string[] = [];
+    let definition: any;
+    try {
+      definition = JSON.parse(card[this.namespacePrefix + 'Definition__c'] || '{}');
+    } catch {
+      return warnings;
+    }
+
+    const walkChildren = (children: any[]) => {
+      for (const child of children || []) {
+        if (child.element === 'customLwc') {
+          const lwcName: string = (child.property?.customlwcname || '').toLowerCase();
+          if (lwcName && lwcMap.has(lwcName)) {
+            warnings.push(
+              this.messages.getMessage('customLwcCrossNamespaceWarning', [
+                child.property.customlwcname,
+                lwcMap.get(lwcName),
+                'FlexCard',
+              ])
+            );
+          }
+        }
+        if (child.children && Array.isArray(child.children)) {
+          walkChildren(child.children);
+        }
+      }
+    };
+
+    for (const state of definition.states || []) {
+      for (const componentKey in state.components || {}) {
+        if (state.components.hasOwnProperty(componentKey)) {
+          walkChildren(state.components[componentKey].children || []);
+        }
+      }
+    }
+
+    return warnings;
   }
 
   /**
@@ -885,10 +943,13 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
     // Map to track cleanedName -> originalName for duplicate detection
     const dupFlexCardNames: Map<string, string> = new Map<string, string>();
 
+    // Build LWC classification map once for the whole migration run
+    const lwcMap = await this.getLwcClassifications();
+
     let progressCounter = 0;
     progressBar.start(cards.length, progressCounter);
     for (let card of cards) {
-      await this.uploadCard(cards, card, cardsUploadInfo, originalRecords, uniqueNames, dupFlexCardNames);
+      await this.uploadCard(cards, card, cardsUploadInfo, originalRecords, uniqueNames, dupFlexCardNames, lwcMap);
       progressBar.update(++progressCounter);
     }
 
@@ -905,7 +966,8 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
     cardsUploadInfo: Map<string, UploadRecordResult>,
     originalRecords: Map<string, any>,
     uniqueNames: Set<string>,
-    dupFlexCardNames: Map<string, string>
+    dupFlexCardNames: Map<string, string>,
+    lwcMap: Map<string, string>
   ) {
     const recordId = card['Id'];
 
@@ -922,7 +984,15 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
           // Upload child cards
           const childCard = allCards.find((c) => c['Name'] === childCardName);
           if (childCard) {
-            await this.uploadCard(allCards, childCard, cardsUploadInfo, originalRecords, uniqueNames, dupFlexCardNames);
+            await this.uploadCard(
+              allCards,
+              childCard,
+              cardsUploadInfo,
+              originalRecords,
+              uniqueNames,
+              dupFlexCardNames,
+              lwcMap
+            );
           }
         }
 
@@ -1038,6 +1108,10 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
             .join(', ');
           uploadResult.errors.push(this.messages.getMessage('integrationProcedureManualUpdateMessage', [val]));
         }
+
+        // Detect cross-namespace LWC risks during migration
+        const lwcWarnings = this.detectCustomLwcEmbeds(card, lwcMap);
+        uploadResult.warnings.push(...lwcWarnings);
 
         cardsUploadInfo.set(recordId, uploadResult);
 

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -625,11 +625,12 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
         // Check for customLwc element
         if (child.element === 'customLwc') {
           const lwcName: string = (child.property?.customlwcname || '').toLowerCase();
-          if (lwcName && lwcMap.has(lwcName) && lwcMap.get(lwcName) === 'custom') {
+          const kind = lwcName ? lwcMap.get(lwcName) : undefined;
+          if (kind !== undefined) {
             warnings.push(
               this.messages.getMessage('customLwcCrossNamespaceWarning', [
                 child.property.customlwcname,
-                lwcMap.get(lwcName),
+                kind,
                 'FlexCard',
               ])
             );
@@ -639,11 +640,12 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
         // Check for flyoutLwc in stateAction
         if (child.property?.stateAction?.flyoutType === 'customLwc') {
           const flyoutLwcName: string = (child.property.stateAction.flyoutLwc || '').toLowerCase();
-          if (flyoutLwcName && lwcMap.has(flyoutLwcName) && lwcMap.get(flyoutLwcName) === 'custom') {
+          const kind = flyoutLwcName ? lwcMap.get(flyoutLwcName) : undefined;
+          if (kind !== undefined) {
             warnings.push(
               this.messages.getMessage('customLwcCrossNamespaceWarning', [
                 child.property.stateAction.flyoutLwc,
-                lwcMap.get(flyoutLwcName),
+                kind,
                 'FlexCard',
               ])
             );
@@ -670,11 +672,12 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
       for (const action of event.actionList || []) {
         if (action.stateAction?.flyoutType === 'customLwc') {
           const flyoutLwcName: string = (action.stateAction.flyoutLwc || '').toLowerCase();
-          if (flyoutLwcName && lwcMap.has(flyoutLwcName) && lwcMap.get(flyoutLwcName) === 'custom') {
+          const kind = flyoutLwcName ? lwcMap.get(flyoutLwcName) : undefined;
+          if (kind !== undefined) {
             warnings.push(
               this.messages.getMessage('customLwcCrossNamespaceWarning', [
                 action.stateAction.flyoutLwc,
-                lwcMap.get(flyoutLwcName),
+                kind,
                 'FlexCard',
               ])
             );

--- a/src/migration/interfaces.ts
+++ b/src/migration/interfaces.ts
@@ -209,6 +209,12 @@ export interface FlexcardStorage extends Storage {
   originalName: string;
 }
 
+export interface LwcBundleRecord {
+  Id?: string;
+  DeveloperName?: string;
+  NamespacePrefix?: string;
+}
+
 export class InvalidEntityTypeError extends Error {
   public constructor(message: string) {
     super(message);

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -700,6 +700,32 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     const uniqueMissingIP = [...new Set(missingIP)];
     const uniqueMissingOS = [...new Set(missingOS)];
 
+    // Check for cross-namespace custom LWC embeds
+    const lwcMap = await this.getLwcClassifications();
+    for (const element of elements) {
+      const elementType: string = element[`${this.namespacePrefix}Type__c`] || '';
+      if (elementType !== 'Custom Lightning Web Component') continue;
+
+      let propertySet: any = {};
+      try {
+        propertySet = JSON.parse(element[`${this.namespacePrefix}PropertySet__c`] || '{}');
+      } catch {
+        continue;
+      }
+
+      const lwcName: string = propertySet['lwcName'] || '';
+      if (!lwcName) continue;
+
+      const kind = lwcMap.get(lwcName.toLowerCase());
+      if (kind !== undefined) {
+        const warning = this.messages.getMessage('customLwcCrossNamespaceWarning', [lwcName, kind, 'OmniScript']);
+        warnings.push(warning);
+        if (assessmentStatus === 'Ready for migration') {
+          assessmentStatus = 'Warnings';
+        }
+      }
+    }
+
     const result: OSAssessmentInfo = {
       name: recordName,
       id: omniscript['Id'],
@@ -877,6 +903,9 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
 
     const functionDefinitionMetadata = await getAllFunctionMetadata(this.namespace, this.connection);
     populateRegexForFunctionMetadata(functionDefinitionMetadata);
+
+    // Build LWC classification map once for the whole migration run
+    const lwcMap = await this.getLwcClassifications();
 
     const duplicatedNames = new Set<string>();
     // Map to track cleanedName (without version) -> originalName (without version) for duplicate detection
@@ -1323,7 +1352,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
 
         try {
           // Upload All elements for each OmniScript__c record(i.e IP/OS)
-          await this.uploadAllElements(osUploadResponse, elements);
+          await this.uploadAllElements(osUploadResponse, elements, lwcMap);
 
           // Get OmniScript Compiled Definitions for OmniScript Record
           const omniscriptsCompiledDefinitions = await this.getOmniScriptCompiledDefinition(recordId);
@@ -1609,7 +1638,8 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
   // Upload All the Elements tagged to a OmniScript__c record, after the parent record has been inserted
   private async uploadAllElements(
     omniScriptUploadResults: UploadRecordResult,
-    elements: AnyJson[]
+    elements: AnyJson[],
+    lwcMap: Map<string, string>
   ): Promise<Map<string, UploadRecordResult>> {
     let levelCount = 0; // To define and insert different levels(Parent-Child relationship) at a time
     let exit = false; // Counter variable to exit after all parent-child elements inserted
@@ -1638,7 +1668,8 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
         let elementsTransformedData = await this.prepareElementsData(
           omniScriptUploadResults,
           tempElements,
-          elementsUploadInfo
+          elementsUploadInfo,
+          lwcMap
         );
         let elementsUploadResponse = new Map<string, UploadRecordResult>();
 
@@ -1714,7 +1745,8 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
   private async prepareElementsData(
     osUploadResult: UploadRecordResult,
     elements: AnyJson[],
-    parentElementUploadResponse: Map<string, UploadRecordResult>
+    parentElementUploadResponse: Map<string, UploadRecordResult>,
+    lwcMap: Map<string, string>
   ): Promise<TransformData> {
     const mappedRecords = [],
       originalRecords = new Map<string, AnyJson>(),
@@ -1730,6 +1762,26 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
 
       // Create a map of the original records
       originalRecords.set(element['Id'], element);
+
+      // Check for cross-namespace LWC embeds and attach warnings
+      const elementType: string = element[`${this.namespacePrefix}Type__c`] || '';
+      if (elementType === 'Custom Lightning Web Component') {
+        let propertySet: any = {};
+        try {
+          propertySet = JSON.parse(element[`${this.namespacePrefix}PropertySet__c`] || '{}');
+        } catch {
+          /* skip unparseable */
+        }
+
+        const lwcName: string = propertySet['lwcName'] || '';
+        const kind = lwcName ? lwcMap.get(lwcName.toLowerCase()) : undefined;
+        if (kind !== undefined) {
+          osUploadResult.warnings = osUploadResult.warnings || [];
+          osUploadResult.warnings.push(
+            this.messages.getMessage('customLwcCrossNamespaceWarning', [lwcName, kind, 'OmniScript'])
+          );
+        }
+      }
     });
 
     if (osUploadResult.id && invalidIpNames.size > 0) {

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -805,6 +805,38 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     return false;
   }
 
+  /**
+   * Scans all elements upfront to detect custom LWC embeds before migration starts.
+   * Used to block migration if cross-namespace LWC issues would occur.
+   * @param elements Array of OmniScript elements to check
+   * @param lwcMap Classification map from getLwcClassifications()
+   * @returns Array of error messages (empty if no issues)
+   */
+  private detectCustomLwcEmbedsInElements(elements: AnyJson[], lwcMap: Map<string, string>): string[] {
+    const errors: string[] = [];
+
+    for (const element of elements) {
+      const elementType: string = element[`${this.namespacePrefix}Type__c`] || '';
+      if (elementType !== 'Custom Lightning Web Component') continue;
+
+      let propertySet: any = {};
+      try {
+        propertySet = JSON.parse(element[`${this.namespacePrefix}PropertySet__c`] || '{}');
+      } catch {
+        continue;
+      }
+
+      // Check lwcName and lwcComponentOverride fields
+      const lwcName: string = propertySet['lwcName'] || '';
+      const lwcOverride: string = propertySet['lwcComponentOverride'] || '';
+
+      this.checkAndWarnForCustomLwc(lwcName, lwcMap, errors);
+      this.checkAndWarnForCustomLwc(lwcOverride, lwcMap, errors);
+    }
+
+    return errors;
+  }
+
   private prepareStorageForRelatedObjectsWhenMetadataAPIEnabled(
     storage: MigrationStorage,
     omniscripts: AnyJson[]
@@ -1319,6 +1351,21 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
       // Save the mapped record
       mappedRecords.push(mappedOmniScript);
 
+      // Block migration if custom LWC embeds detected (check BEFORE upload)
+      const lwcErrors = this.detectCustomLwcEmbedsInElements(elements, lwcMap);
+      if (lwcErrors.length > 0) {
+        const osUploadResponse = {
+          referenceId: recordId,
+          hasErrors: true,
+          success: false,
+          errors: lwcErrors,
+          warnings: [],
+        };
+        osUploadInfo.set(recordId, osUploadResponse);
+        originalOsRecords.set(recordId, omniscript);
+        continue;
+      }
+
       // Save the OmniScript__c records to Standard BPO i.e OmniProcess
       let osUploadResponse;
       if (!this.IS_STANDARD_DATA_MODEL) {
@@ -1807,25 +1854,6 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
 
       // Create a map of the original records
       originalRecords.set(element['Id'], element);
-
-      // Check for cross-namespace LWC embeds and attach warnings
-      const elementType: string = element[`${this.namespacePrefix}Type__c`] || '';
-      if (elementType === 'Custom Lightning Web Component') {
-        let propertySet: any = {};
-        try {
-          propertySet = JSON.parse(element[`${this.namespacePrefix}PropertySet__c`] || '{}');
-        } catch {
-          /* skip unparseable */
-        }
-
-        // Check lwcName and lwcComponentOverride fields
-        const lwcName: string = propertySet['lwcName'] || '';
-        const lwcOverride: string = propertySet['lwcComponentOverride'] || '';
-
-        osUploadResult.warnings = osUploadResult.warnings || [];
-        this.checkAndWarnForCustomLwc(lwcName, lwcMap, osUploadResult.warnings);
-        this.checkAndWarnForCustomLwc(lwcOverride, lwcMap, osUploadResult.warnings);
-      }
     });
 
     if (osUploadResult.id && invalidIpNames.size > 0) {

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -786,7 +786,8 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
   }
 
   /**
-   * Helper method to check if an LWC reference is custom and add warning if needed
+   * Helper method to check if an LWC reference is unmanaged and add warning if needed.
+   * All unmanaged LWCs (regardless of naming pattern) can cause cross-namespace issues.
    * @param lwcName The LWC name to check
    * @param lwcMap The LWC classification map
    * @param warnings Array to push warnings to
@@ -796,7 +797,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     if (!lwcName) return false;
 
     const kind = lwcMap.get(lwcName.toLowerCase());
-    if (kind === 'custom') {
+    if (kind !== undefined) {
       const warning = this.messages.getMessage('customLwcCrossNamespaceWarning', [lwcName, kind, 'OmniScript']);
       warnings.push(warning);
       return true;

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -713,15 +713,29 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
         continue;
       }
 
+      // Check lwcName field
       const lwcName: string = propertySet['lwcName'] || '';
-      if (!lwcName) continue;
+      if (lwcName) {
+        const kind = lwcMap.get(lwcName.toLowerCase());
+        if (kind === 'custom') {
+          const warning = this.messages.getMessage('customLwcCrossNamespaceWarning', [lwcName, kind, 'OmniScript']);
+          warnings.push(warning);
+          if (assessmentStatus === 'Ready for migration') {
+            assessmentStatus = 'Warnings';
+          }
+        }
+      }
 
-      const kind = lwcMap.get(lwcName.toLowerCase());
-      if (kind !== undefined) {
-        const warning = this.messages.getMessage('customLwcCrossNamespaceWarning', [lwcName, kind, 'OmniScript']);
-        warnings.push(warning);
-        if (assessmentStatus === 'Ready for migration') {
-          assessmentStatus = 'Warnings';
+      // Check lwcComponentOverride field
+      const lwcOverride: string = propertySet['lwcComponentOverride'] || '';
+      if (lwcOverride) {
+        const kind = lwcMap.get(lwcOverride.toLowerCase());
+        if (kind === 'custom') {
+          const warning = this.messages.getMessage('customLwcCrossNamespaceWarning', [lwcOverride, kind, 'OmniScript']);
+          warnings.push(warning);
+          if (assessmentStatus === 'Ready for migration') {
+            assessmentStatus = 'Warnings';
+          }
         }
       }
     }
@@ -1773,13 +1787,28 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
           /* skip unparseable */
         }
 
+        // Check lwcName field
         const lwcName: string = propertySet['lwcName'] || '';
-        const kind = lwcName ? lwcMap.get(lwcName.toLowerCase()) : undefined;
-        if (kind !== undefined) {
-          osUploadResult.warnings = osUploadResult.warnings || [];
-          osUploadResult.warnings.push(
-            this.messages.getMessage('customLwcCrossNamespaceWarning', [lwcName, kind, 'OmniScript'])
-          );
+        if (lwcName) {
+          const kind = lwcMap.get(lwcName.toLowerCase());
+          if (kind === 'custom') {
+            osUploadResult.warnings = osUploadResult.warnings || [];
+            osUploadResult.warnings.push(
+              this.messages.getMessage('customLwcCrossNamespaceWarning', [lwcName, kind, 'OmniScript'])
+            );
+          }
+        }
+
+        // Check lwcComponentOverride field
+        const lwcOverride: string = propertySet['lwcComponentOverride'] || '';
+        if (lwcOverride) {
+          const kind = lwcMap.get(lwcOverride.toLowerCase());
+          if (kind === 'custom') {
+            osUploadResult.warnings = osUploadResult.warnings || [];
+            osUploadResult.warnings.push(
+              this.messages.getMessage('customLwcCrossNamespaceWarning', [lwcOverride, kind, 'OmniScript'])
+            );
+          }
         }
       }
     });


### PR DESCRIPTION
### What does this PR do?

Adds warnings for FlexCards and OmniScripts that embed custom LWCs. After migration, the auto-generated FlexCard/OmniScript LWCs keep the vertical namespace (like `vlocity_ins__`) but any custom LWCs inside them move to `c/`, which breaks at runtime with cross-reference errors.

Now the assess and migrate commands will flag these cases and suggest using `omnistudio-standard-runtime-wrapper` or enabling Lightning Web Security as a workaround.

**What changed:**
- Added `getLwcClassifications()` in base.ts to query Tooling API and figure out which LWCs are custom vs auto-generated
- Added detection logic in FlexCard and OmniScript tools to scan for embedded custom LWCs during both assessment and migration
- New warning message points users to the workaround

### What issues does this PR fix or reference?

Fixes W-19835755 - the Prudential cross-reference error issue where FlexCards/OmniScripts with custom LWCs fail post-migration.

Assesmode:

<img width="1649" height="910" alt="image" src="https://github.com/user-attachments/assets/9caf5261-1097-493b-bcf7-83fc9cb8bce0" />

<img width="1728" height="1044" alt="image" src="https://github.com/user-attachments/assets/41594917-6ca5-41ba-81b6-5ed6fb1bb836" />



