### PR TITLE
@W-22403162: Auto-enable PreHook/PostHook on IPs migrated from managed package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.6.1](https://github.com/salesforcecli/plugin-omnistudio-migration-tool/compare/1.6.0...1.6.1) (2025-09-12)
+
+
+
 # [1.6.0](https://github.com/salesforcecli/plugin-omnistudio-migration-tool/compare/1.5.0...1.6.0) (2024-09-12)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [1.7.0](https://github.com/salesforcecli/plugin-omnistudio-migration-tool/compare/1.6.1...1.7.0) (2025-11-07)
+
+
+### Features
+
+* @W-19700286: [OMT] [Migration] Implemention of Guardrail and validation ([55fd750](https://github.com/salesforcecli/plugin-omnistudio-migration-tool/commit/55fd75039d92e42198580a577279c78122207400))
+
+
+
 ## [1.6.1](https://github.com/salesforcecli/plugin-omnistudio-migration-tool/compare/1.6.0...1.6.1) (2025-09-12)
 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # OmniStudio Migration Tool
 
-### Before You Begin
+## 🚀 Before You Begin
 
-Read and follow the directions in the Omnistudio migration documentation: https://help.salesforce.com/s/articleView?id=sf.os_migrate_omnistudio_custom_objects_to_standard_objects.htm&type=5
+⚠️ IMPORTANT: Before installing and using the Omnistudio Migration Tool, contact Salesforce support.
+
+Follow the steps in [Migration Process from Omnistudio for Managed Packages to Omnistudio](https://help.salesforce.com/s/articleView?id=xcloud.os_migrate_omnistudio_custom_objects_to_standard_objects.htm&language=en_US&type=5)
 
 ## Running SFDX plugin
 

--- a/messages/migrate.json
+++ b/messages/migrate.json
@@ -25,5 +25,8 @@
   "errorWhileActivatingCard": "Could not activate Card: ",
   "errorWhileUploadingCard": "An error ocurred while uploading Card: ",
   "errorWhileCreatingElements": "An error ocurred while saving OmniScript elements: ",
-  "allVersionsDescription": "Migrate all versions of a component"
+  "allVersionsDescription": "Migrate all versions of a component",
+  "noPackageInstalled": "No managed package found in your org.",
+  "alreadyStandardModel": "Migration cannot proceed for the org %s as the org already uses the standard data model. Contact Salesforce support.",
+  "invalidNamespace": "Invalid namespace value provided: %s. Try again with the correct namespace value."
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-omnistudio-migration-tool",
   "description": "This SFDX plugin migrates FlexCard, OmniScript, DataRaptor, and Integration Procedure custom objects to standard objects.",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-omnistudio-migration-tool",
   "description": "This SFDX plugin migrates FlexCard, OmniScript, DataRaptor, and Integration Procedure custom objects to standard objects.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -15,6 +15,7 @@ import { UX } from '@salesforce/command';
 export class OmniScriptMigrationTool extends BaseMigrationTool implements MigrationTool {
   private readonly exportType: OmniScriptExportType;
   private readonly allVersions: boolean;
+  private hasCpqAppHandlerHook: boolean = false;
 
   // Source Custom Object Names
   static readonly OMNISCRIPT_NAME = 'OmniScript__c';
@@ -38,6 +39,18 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     super(namespace, connection, logger, messages, ux);
     this.exportType = exportType;
     this.allVersions = allVersions;
+  }
+
+  private async checkCpqAppHandlerHook(): Promise<boolean> {
+    try {
+      const objectName = `${this.namespacePrefix}CustomClassImplementation__c`;
+      const soql = `SELECT Id FROM ${objectName} WHERE Name = 'CpqAppHandlerHook' LIMIT 1`;
+      const result = await this.connection.query(soql);
+      return result.totalSize > 0;
+    } catch (e) {
+      this.logger.warn('Unable to query CustomClassImplementation__c for CpqAppHandlerHook: ' + e);
+      return false;
+    }
   }
 
   getName(): string {
@@ -163,6 +176,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
   async migrate(): Promise<MigrationResult[]> {
     // Get All Records from OmniScript__c (IP & OS Parent Records)
     const omniscripts = await this.getAllOmniScripts();
+    this.hasCpqAppHandlerHook = await this.checkCpqAppHandlerHook();
     const duplicatedNames = new Set<string>();
 
     // Variables to be returned After Migration
@@ -646,6 +660,14 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
             invalidIpReferences.set(mappedObject[ElementMappings.Name], key);
           }
           propertySet['integrationProcedureKey'] = newKey;
+        }
+        break;
+      case 'Remote Action':
+        if (this.hasCpqAppHandlerHook) {
+          const raRemoteOptions = propertySet['remoteOptions'] || {};
+          raRemoteOptions['PreHook'] = true;
+          raRemoteOptions['PostHook'] = true;
+          propertySet['remoteOptions'] = raRemoteOptions;
         }
         break;
       case 'DataRaptor Turbo Action':

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,5 @@
 export * from './query';
 export * from './logging/debugtimer';
 export * from './interfaces';
+export * from './orgUtils';
+export * from './orgPreferences';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,20 +1,107 @@
 import { UX } from '@salesforce/command';
 import { Logger as SfLogger } from '@salesforce/core';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { FileLogger } from './logger/fileLogger';
 
 export class Logger {
   private static sfUX: UX;
   private static sfLogger: SfLogger;
+  private static verbose = false;
 
-  public static initialiseLogger(ux: UX, logger: SfLogger): Logger {
+  public static initialiseLogger(ux: UX, logger: SfLogger, command?: string, verbose?: boolean): Logger {
     Logger.sfUX = ux;
     Logger.sfLogger = logger;
+    Logger.verbose = verbose || false;
+    FileLogger.initialize(command || 'default');
     return Logger;
+  }
+
+  public static setVerbose(isVerbose: boolean): void {
+    Logger.verbose = isVerbose;
+  }
+
+  public static getVerbose(): boolean {
+    return Logger.verbose;
+  }
+
+  public static logVerbose(message: string): void {
+    if (Logger.verbose && Logger.sfUX) {
+      Logger.sfUX.log(message);
+    }
+    FileLogger.writeLog('VERBOSE', message);
+  }
+
+  public static captureVerboseData(message: string, data: unknown): void {
+    if (Logger.verbose) {
+      FileLogger.writeLog('VERBOSE DATA', `${message}: ${JSON.stringify(data)}`);
+    }
   }
 
   public static get logger(): SfLogger {
     return Logger.sfLogger;
   }
+
   public static get ux(): UX {
     return Logger.sfUX;
+  }
+
+  public static log(message: string): void {
+    if (Logger.sfUX) {
+      Logger.sfUX.log(message);
+    }
+    FileLogger.writeLog('INFO', message);
+  }
+
+  public static warn(message: string): void {
+    if (Logger.sfUX) {
+      Logger.sfUX.warn(message);
+    }
+    FileLogger.writeLog('WARN', message);
+  }
+
+  public static error(message: string | Error, error?: Error): void {
+    if (Logger.sfUX) {
+      if (message instanceof Error) {
+        Logger.sfUX.error(`\x1b[31m${message.message}\n${message.stack}\x1b[0m`);
+      } else {
+        if (error) {
+          Logger.sfUX.error(`\x1b[31m${error.message}\n${error.stack}\x1b[0m`);
+        } else {
+          Logger.sfUX.error(`\x1b[31m${message}\x1b[0m`);
+        }
+      }
+    }
+    FileLogger.writeLog('ERROR', message instanceof Error ? `${message.message}\n${message.stack}` : message);
+  }
+
+  public static debug(message: string): void {
+    if (Logger.sfLogger) {
+      Logger.sfLogger.debug(message);
+    }
+    FileLogger.writeLog('DEBUG', message);
+  }
+
+  public static info(message: string): void {
+    if (Logger.sfLogger) {
+      Logger.sfLogger.info(message);
+    }
+    FileLogger.writeLog('INFO', message);
+  }
+
+  public static confirm(message: string): Promise<boolean> {
+    if (Logger.sfUX) {
+      FileLogger.writeLog('CONFIRM', message);
+      return Logger.sfUX.confirm(message);
+    }
+    return Promise.resolve(false);
+  }
+
+  public static prompt(message: string): Promise<string> {
+    if (Logger.sfUX) {
+      FileLogger.writeLog('PROMPT', message);
+      return Logger.sfUX.prompt(message);
+    }
+    return Promise.resolve('');
   }
 }

--- a/src/utils/logger/fileLogger.ts
+++ b/src/utils/logger/fileLogger.ts
@@ -1,0 +1,62 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Logger } from '../logger';
+
+export class FileLogger {
+  private static logDir = path.resolve(process.cwd(), 'logs');
+  private static currentLogFile: string | null = null;
+  private static isInitialized = false;
+
+  public static initialize(command = 'default'): void {
+    if (this.isInitialized) {
+      return;
+    }
+
+    try {
+      // Create logs directory if it doesn't exist
+      if (!fs.existsSync(this.logDir)) {
+        fs.mkdirSync(this.logDir, { recursive: true });
+      }
+
+      // Create log file with timestamp and command name
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      this.currentLogFile = path.join(this.logDir, `${timestamp}_${command}.log`);
+
+      // Create an empty log file to ensure it exists
+      fs.writeFileSync(this.currentLogFile, '');
+
+      this.isInitialized = true;
+      Logger.logVerbose(`Log file initialized at: ${this.currentLogFile}`);
+    } catch (error: unknown) {
+      const err = error as Error;
+      Logger.error(`Error initializing FileLogger: ${err.message}\n${err.stack}`);
+      // Fallback to console logging if file system operations fail
+      this.currentLogFile = null;
+    }
+  }
+
+  public static writeLog(level: string, message: string): void {
+    // Initialize with default command if not already initialized
+    if (!this.isInitialized) {
+      this.initialize();
+    }
+
+    if (!this.currentLogFile) {
+      // Fallback to console logging if file logging is not available
+      Logger.log(`[${level}] ${message}`);
+      return;
+    }
+
+    const timestamp = new Date().toISOString();
+    const logEntry = `[${timestamp}] [${level}] ${message}\n`;
+
+    try {
+      fs.appendFileSync(this.currentLogFile, logEntry);
+    } catch (error: unknown) {
+      const err = error as Error;
+      Logger.error(`Error writing to log file: ${err.message}\n${err.stack}`);
+      // Fallback to console logging
+      Logger.log(`[${level}] ${message}`);
+    }
+  }
+}

--- a/src/utils/orgPreferences.ts
+++ b/src/utils/orgPreferences.ts
@@ -1,0 +1,51 @@
+import { Connection } from '@salesforce/core';
+import { Logger } from './logger';
+
+/**
+ * Class to manage OmniStudio organization preferences
+ *
+ * @class OrgPreferences
+ * @description Provides functionality to enable OmniStudio preferences and check rollback flags
+ */
+export class OrgPreferences {
+  /**
+   * Checks if OmniStudio designers are already using the standard data model for the specific package.
+   *
+   * @public
+   * @static
+   * @async
+   * @param {Connection} connection - Salesforce connection instance
+   * @param {string} namespaceToModify - The namespace to check for standard designer
+   * @throws {Error} If checking the standard designer status fails
+   * @returns {Promise<boolean>} True if standard designer is enabled, false otherwise
+   */
+
+  public static async isStandardDesignerEnabled(connection: Connection, namespaceToModify: string): Promise<boolean> {
+    try {
+      const query = `SELECT DeveloperName, Value FROM OmniInteractionConfig
+      WHERE DeveloperName IN ('TheFirstInstalledOmniPackage', 'InstalledIndustryPackage')`;
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const result = await connection.query(query);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if (result?.totalSize > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        const records = result.records as Array<{ DeveloperName: string; Value: string }>;
+
+        for (const record of records) {
+          if (record.Value === namespaceToModify) {
+            return true;
+          }
+        }
+        return false;
+      } else {
+        return false;
+      }
+    } catch (error) {
+      // TODO: What should be the default behavior if the query fails?
+      const errMsg = error instanceof Error ? error.message : String(error);
+      Logger.error(`Error checking standard designer for namespace ${namespaceToModify}: ${errMsg}`);
+      return false;
+    }
+  }
+}

--- a/src/utils/orgUtils/index.ts
+++ b/src/utils/orgUtils/index.ts
@@ -1,0 +1,364 @@
+/* eslint-disable */
+import { Connection } from '@salesforce/core';
+import { QueryTools } from '../query';
+import { OrgPreferences } from '../orgPreferences';
+
+interface InstalledPackage {
+  MajorVersion: number;
+  MinorVersion: number;
+  NamespacePrefix: string;
+  Name: string;
+}
+
+interface OrgDetails {
+  Name: string;
+  Id: string;
+}
+
+export interface OmnistudioOrgDetails {
+  packageDetails: PackageDetail;
+  omniStudioOrgPermissionEnabled: boolean;
+  orgDetails: OrgDetails;
+  dataModel: string;
+  hasValidNamespace: boolean;
+  rollbackFlags?: string[];
+}
+
+export interface PackageDetail {
+  version: string;
+  namespace: string;
+}
+
+export class OrgUtils {
+  /**
+   * Skip the 'omnistudio' namespace because it belongs to the foundation package,
+   * which already works with the standard model and does not need migration.
+   * */
+  private static readonly namespaces = new Set<string>([
+    'as_dev_01',
+    'as_dev_02',
+    'as_dev_03',
+    'as_dev_04',
+    'as_dev_05',
+    'as_dev_06',
+    'as_dev_07',
+    'as_dev_08',
+    'as_dev_09',
+    'as_dev_10',
+    'as_dev_11',
+    'as_dev_12',
+    'as_dev_13',
+    'as_dev_14',
+    'as_dev_15',
+    'as_dev_16',
+    'as_dev_17',
+    'as_dev_18',
+    'as_dev_19',
+    'as_dev_20',
+    'cci_01',
+    'cci_02',
+    'cci_03',
+    'cci_04',
+    'cci_05',
+    'cci_06',
+    'cci_07',
+    'clm_dev_01',
+    'clm_dev_02',
+    'clm_dev_03',
+    'clm_dev_04',
+    'clm_dev_05',
+    'clm_dev_06',
+    'clm_dev_07',
+    'clm_dev_08',
+    'clm_dev_09',
+    'clm_dev_10',
+    'clm_dev_11',
+    'clm_dev_12',
+    'clm_dev_13',
+    'clm_dev_14',
+    'clm_dev_15',
+    'clm_dev_16',
+    'clm_dev_17',
+    'clm_dev_18',
+    'clm_dev_19',
+    'clm_dev_20',
+    'clm_dev_21',
+    'clm_dev_22',
+    'clm_dev_23',
+    'clm_dev_24',
+    'clm_dev_25',
+    'clm_dev_26',
+    'clm_dev_27',
+    'clm_dev_28',
+    'clm_dev_29',
+    'clm_dev_30',
+    'common',
+    'devops001gs0',
+    'devops002gs0',
+    'devops003gs0',
+    'devops004gs0',
+    'devops005gs0',
+    'devops006r1',
+    'devops007r1',
+    'devops008r1',
+    'devops009r1',
+    'devops010r1',
+    'devopsimpkg01',
+    'devopsimpkg11',
+    'devopsimpkg12',
+    'devopsimpkg13',
+    'devopsimpkg14',
+    'devopsimpkg15',
+    'devopsimpkg16',
+    'devopsimpkg17',
+    'devopsimpkg18',
+    'devopsimpkg19',
+    'devopsimpkg20',
+    'devopsimpkg21',
+    'devopsimpkg22',
+    'devopsimpkg23',
+    'devopsimpkg24',
+    'devopsimpkg25',
+    'devopsimpkg26',
+    'foundationpkgtest',
+    'industries001',
+    'industriesgs0',
+    'ins_exp_pc01',
+    'ins_exp_pc02',
+    'ins_exp_pc03',
+    'ins_exp_vb01',
+    'ins_exp_vb02',
+    'ins_exp_vb03',
+    'ins_fsc04_gs0',
+    'instest12',
+    'kc_na46',
+    'pc_dev_na46',
+    'pc_qe_na46',
+    'perf_dc230',
+    'scalpel',
+    'sfi_media_1',
+    'sfi_media_2',
+    'sfi_media_3',
+    'sfi_media_4',
+    'sfi_media_5',
+    'sfi_media_6',
+    'sfi_media_7',
+    'sfi_media_8',
+    'sfi_media_9',
+    'sfi_media_10',
+    'slncloud_na81_0',
+    'slncloud_na81_1',
+    'slncloud_r1_01',
+    'slncloud_r1_02',
+    'slncloud_stg_01',
+    'slncloud_test',
+    'solutioncloud',
+    'stmfahins01_oie',
+    'stmpahins01',
+    'vb_dev_na46',
+    'vb_qe_na46',
+    'vlocity_bmk',
+    'vlocity_clmperf',
+    'vlocity_cmt',
+    'vlocity_cpq1',
+    'vlocity_cpq2',
+    'vlocity_cpq3',
+    'vlocity_cpq4',
+    'vlocity_cpq5',
+    'vlocity_cpq6',
+    'vlocity_cpq7',
+    'vlocity_cpq8',
+    'vlocity_cpq9',
+    'vlocity_cpq10',
+    'vlocity_cpq11',
+    'vlocity_cpq12',
+    'vlocity_cpq13',
+    'vlocity_cpq14',
+    'vlocity_cpq15',
+    'vlocity_cpq16',
+    'vlocity_cpq17',
+    'vlocity_cpq18',
+    'vlocity_cpq19',
+    'vlocity_cpq20',
+    'vlocity_cpq21',
+    'vlocity_cpq22',
+    'vlocity_cpq23',
+    'vlocity_cpq24',
+    'vlocity_cpq25',
+    'vlocity_cpq26',
+    'vlocity_cpq27',
+    'vlocity_cpq28',
+    'vlocity_cpq29',
+    'vlocity_cpq30',
+    'vlocity_cpq31',
+    'vlocity_cpq32',
+    'vlocity_cpq33',
+    'vlocity_cpq34',
+    'vlocity_cpq35',
+    'vlocity_cpq36',
+    'vlocity_cpq37',
+    'vlocity_cpq38',
+    'vlocity_cpq39',
+    'vlocity_cpq40',
+    'vlocity_dc',
+    'vlocity_digital',
+    'vlocity_erg',
+    'vlocity_fsc_gs0',
+    'vlocity_ins',
+    'vlocity_ins_fsc',
+    'vlocity_lwc1',
+    'vlocity_lwc2',
+    'vlocity_lwc3',
+    'vlocity_lwc4',
+    'vlocity_lwc5',
+    'vlocity_lwc6',
+    'vlocity_lwc7',
+    'vlocity_lwc8',
+    'vlocity_lwc9',
+    'vlocity_lwc10',
+    'vlocity_lwc11',
+    'vlocity_lwc12',
+    'vlocity_lwc13',
+    'vlocity_lwc14',
+    'vlocity_lwc15',
+    'vlocity_lwc16',
+    'vlocity_lwc17',
+    'vlocity_lwc18',
+    'vlocity_lwc19',
+    'vlocity_lwc20',
+    'vlocity_lwc21',
+    'vlocity_lwc22',
+    'vlocity_lwc23',
+    'vlocity_lwc24',
+    'vlocity_lwc25',
+    'vlocity_lwc26',
+    'vlocity_lwc27',
+    'vlocity_lwc28',
+    'vlocity_lwc29',
+    'vlocity_lwc30',
+    'vlocity_lwc31',
+    'vlocity_lwc32',
+    'vlocity_lwc33',
+    'vlocity_lwctest',
+    'vlocity_perf',
+    'vlocity_ps',
+    'vlocity_upc',
+    'vlocityins1',
+    'vlocityins2',
+    'vlocityins2_fsc',
+    'vlocityins3',
+    'vlocityins4',
+    'vlocityins5',
+    'vlocityins6',
+    'vlocityins7',
+    'vlocityins8',
+    'vlocityins9',
+    'vlocityins10',
+    'vlocityins11',
+    'vlocityins12',
+    'vlocityins13',
+    'vlocityins14',
+    'vlocityins16',
+    'vlocityins17',
+    'vlocityins19',
+  ]);
+
+  // Define the fields to retrieve from the Publisher object
+  private static readonly fields = ['MajorVersion', 'MinorVersion', 'NamespacePrefix', 'Name'];
+
+  // Define the object name for querying installed packages
+  private static readonly objectName = 'Publisher';
+
+  // Define the fields to retrieve from the Organization object
+  private static readonly orgFields = ['Name'];
+
+  // Define the object name for querying installed packages
+  private static readonly orgObjectName = 'Organization';
+
+  private static readonly standardDataModel = 'Standard';
+  private static readonly customDataModel = 'Custom';
+  /**
+   * Fetches package details (version and namespace) for specific installed packages.
+   *
+   * @param connection - Salesforce connection object
+   * @returns Promise resolving to an array of PackageDetail objects
+   */
+  public static async getOrgDetails(connection: Connection, namespace: string): Promise<OmnistudioOrgDetails> {
+    // Query all installed packages and cast the result to InstalledPackage[]
+    const filters = new Map<string, any>();
+    filters.set('NamespacePrefix', namespace);
+
+    const installedOmniPackagesResult = (await QueryTools.queryWithFilter(
+      connection,
+      '',
+      this.objectName,
+      this.fields,
+      filters
+    )) as unknown as InstalledPackage[];
+
+    let hasValidNamespace = true;
+    const orgDetails = (await QueryTools.queryAll(
+      connection,
+      '',
+      this.orgObjectName,
+      this.orgFields
+    )) as unknown as OrgDetails;
+
+    let packageDetails: PackageDetail = {
+      version: '',
+      namespace: '',
+    };
+
+    const installedOmniPackages = [];
+    for (const pkg of installedOmniPackagesResult) {
+      if (this.namespaces.has(pkg.NamespacePrefix)) {
+        installedOmniPackages.push(pkg);
+      }
+    }
+
+    // Handle multiple packages by prompting user to select one
+    if (installedOmniPackages.length === 1) {
+      // Only one package found, use it automatically
+      const pkg = installedOmniPackages[0];
+      packageDetails.version = `${pkg.MajorVersion}.${pkg.MinorVersion}`;
+      packageDetails.namespace = pkg.NamespacePrefix;
+    } else {
+      // return to validate the org information
+      return {
+        packageDetails: undefined,
+        omniStudioOrgPermissionEnabled: false,
+        orgDetails: orgDetails[0],
+        dataModel: undefined,
+        hasValidNamespace: false,
+      };
+    }
+
+    //Execute apex rest resource to get omnistudio org permission
+    const omniStudioOrgPermissionEnabled: boolean = await this.isOmniStudioOrgPermissionEnabled(
+      connection,
+      packageDetails.namespace
+    );
+
+    return {
+      packageDetails: packageDetails,
+      omniStudioOrgPermissionEnabled: omniStudioOrgPermissionEnabled,
+      orgDetails: orgDetails[0],
+      dataModel: omniStudioOrgPermissionEnabled ? this.standardDataModel : this.customDataModel,
+      hasValidNamespace: hasValidNamespace,
+    };
+  }
+
+  /**     *
+   * @param connection  Salesforce connection object
+   * @param namespace namespace of the org which is required to hit the apex rest resource.
+   * @returns
+   */
+  public static async isOmniStudioOrgPermissionEnabled(connection: Connection, namespace: string): Promise<boolean> {
+    try {
+      return await connection.apex.get('/' + namespace + '/v1/orgPermission');
+    } catch (e) {
+      // Any error in the apex mechanism will fallback to check the standard designer status
+      return await OrgPreferences.isStandardDesignerEnabled(connection, namespace);
+    }
+  }
+}

--- a/src/utils/query/index.ts
+++ b/src/utils/query/index.ts
@@ -6,7 +6,9 @@ export class QueryTools {
   public static buildCustomObjectQuery(namespace: string, name: string, fields: string[], filters?: Map<string, any>) {
     const queryFields = this.buildCustomObjectFields(namespace, ['Id', ...fields]);
 
-    let query = 'SELECT ' + queryFields.join(', ') + ' FROM ' + namespace + '__' + name;
+    let query = namespace
+      ? 'SELECT ' + queryFields.join(', ') + ' FROM ' + namespace + '__' + name
+      : 'SELECT ' + queryFields.join(', ') + ' FROM ' + name;
 
     const andFilters = [];
     if (filters && filters.size > 0) {

--- a/test/migration/omniscript.test.ts
+++ b/test/migration/omniscript.test.ts
@@ -1,0 +1,476 @@
+/* eslint-disable */
+/// <reference types="mocha" />
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { OmniScriptMigrationTool, OmniScriptExportType } from '../../src/migration/omniscript';
+import { DebugTimer } from '../../src/utils/logging/debugtimer';
+
+describe('OmniScriptMigrationTool - Remote Action PreHook/PostHook', () => {
+  let sandbox: sinon.SinonSandbox;
+  let mockConnection: any;
+  let mockLogger: any;
+  let mockMessages: any;
+  let mockUx: any;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    DebugTimer.getInstance().start();
+
+    mockConnection = {
+      query: sandbox.stub(),
+      queryMore: sandbox.stub(),
+    };
+
+    mockLogger = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      debug: sandbox.stub(),
+      error: sandbox.stub(),
+    };
+
+    mockMessages = {
+      getMessage: sandbox.stub().returns(''),
+    };
+
+    mockUx = {
+      log: sandbox.stub(),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function createTool(namespace: string = 'vlocity_ins'): OmniScriptMigrationTool {
+    return new OmniScriptMigrationTool(
+      OmniScriptExportType.IP,
+      namespace,
+      mockConnection,
+      mockLogger,
+      mockMessages,
+      mockUx,
+      false
+    );
+  }
+
+  function createRemoteActionElement(namespace: string, remoteOptions: Record<string, any> = {}): Record<string, any> {
+    const prefix = namespace ? namespace + '__' : '';
+    return {
+      Id: 'elemId001',
+      [`${prefix}Type__c`]: 'Remote Action',
+      [`${prefix}PropertySet__c`]: JSON.stringify({ remoteOptions }),
+      [`${prefix}OmniScriptId__c`]: 'osId001',
+      [`${prefix}Level__c`]: 0,
+      [`${prefix}ParentElementId__c`]: null,
+      [`${prefix}Name`]: 'TestRemoteAction',
+      [`${prefix}Active__c`]: true,
+      [`${prefix}Order__c`]: 1,
+    };
+  }
+
+  function createNonRemoteActionElement(
+    namespace: string,
+    elementType: string = 'Integration Procedure Action'
+  ): Record<string, any> {
+    const prefix = namespace ? namespace + '__' : '';
+    return {
+      Id: 'elemId002',
+      [`${prefix}Type__c`]: elementType,
+      [`${prefix}PropertySet__c`]: JSON.stringify({
+        remoteOptions: { preTransformBundle: 'MyBundle', postTransformBundle: 'OtherBundle' },
+        integrationProcedureKey: 'Type_SubType',
+      }),
+      [`${prefix}OmniScriptId__c`]: 'osId001',
+      [`${prefix}Level__c`]: 0,
+      [`${prefix}ParentElementId__c`]: null,
+      [`${prefix}Name`]: 'TestIPAction',
+      [`${prefix}Active__c`]: true,
+      [`${prefix}Order__c`]: 2,
+    };
+  }
+
+  describe('migrate() with CpqAppHandlerHook registered', () => {
+    it('should set PreHook=true and PostHook=true on Remote Action elements', async () => {
+      const namespace = 'vlocity_ins';
+      const tool = createTool(namespace);
+
+      // Hook query returns a record
+      mockConnection.query.callsFake((soql: string) => {
+        if (soql.includes('CustomClassImplementation__c')) {
+          return Promise.resolve({ totalSize: 1, records: [{ Id: 'hookId001', Name: 'CpqAppHandlerHook' }] });
+        }
+        if (soql.includes('OmniScript__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [
+              {
+                Id: 'osId001',
+                [`${namespace}__Type__c`]: 'TestType',
+                [`${namespace}__SubType__c`]: 'TestSubType',
+                [`${namespace}__Language__c`]: 'English',
+                [`${namespace}__Version__c`]: 1,
+                [`${namespace}__IsActive__c`]: false,
+                [`${namespace}__IsProcedure__c`]: true,
+              },
+            ],
+          });
+        }
+        if (soql.includes('Element__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [createRemoteActionElement(namespace)],
+          });
+        }
+        if (soql.includes('OmniScriptDefinition__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      });
+
+      // Stub the NetUtils create call to capture the mapped element
+      const { NetUtils } = require('../../src/utils/net');
+      const createStub = sandbox.stub(NetUtils, 'create');
+      const createOneStub = sandbox.stub(NetUtils, 'createOne');
+
+      createOneStub.resolves({
+        id: 'newOsId001',
+        success: true,
+        errors: [],
+        warnings: [],
+      });
+
+      let capturedElements: any[] = [];
+      createStub.callsFake((_conn: any, objectName: string, records: any[]) => {
+        if (objectName === 'OmniProcessElement') {
+          capturedElements = records;
+        }
+        const resultMap = new Map();
+        for (const rec of records) {
+          resultMap.set(rec.attributes.referenceId, {
+            id: 'new_' + rec.attributes.referenceId,
+            success: true,
+            errors: [],
+          });
+        }
+        return Promise.resolve(resultMap);
+      });
+
+      await tool.migrate();
+
+      expect(capturedElements).to.have.lengthOf(1);
+      const propertySet = JSON.parse(capturedElements[0].PropertySetConfig);
+      expect(propertySet.remoteOptions.PreHook).to.equal(true);
+      expect(propertySet.remoteOptions.PostHook).to.equal(true);
+
+      createStub.restore();
+      createOneStub.restore();
+    });
+  });
+
+  describe('migrate() without CpqAppHandlerHook registered', () => {
+    it('should not modify remoteOptions on Remote Action elements', async () => {
+      const namespace = 'vlocity_ins';
+      const tool = createTool(namespace);
+
+      // Hook query returns no records
+      mockConnection.query.callsFake((soql: string) => {
+        if (soql.includes('CustomClassImplementation__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        if (soql.includes('OmniScript__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [
+              {
+                Id: 'osId001',
+                [`${namespace}__Type__c`]: 'TestType',
+                [`${namespace}__SubType__c`]: 'TestSubType',
+                [`${namespace}__Language__c`]: 'English',
+                [`${namespace}__Version__c`]: 1,
+                [`${namespace}__IsActive__c`]: false,
+                [`${namespace}__IsProcedure__c`]: true,
+              },
+            ],
+          });
+        }
+        if (soql.includes('Element__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [createRemoteActionElement(namespace, { someExisting: 'value' })],
+          });
+        }
+        if (soql.includes('OmniScriptDefinition__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      });
+
+      const { NetUtils } = require('../../src/utils/net');
+      const createStub = sandbox.stub(NetUtils, 'create');
+      const createOneStub = sandbox.stub(NetUtils, 'createOne');
+
+      createOneStub.resolves({
+        id: 'newOsId001',
+        success: true,
+        errors: [],
+        warnings: [],
+      });
+
+      let capturedElements: any[] = [];
+      createStub.callsFake((_conn: any, objectName: string, records: any[]) => {
+        if (objectName === 'OmniProcessElement') {
+          capturedElements = records;
+        }
+        const resultMap = new Map();
+        for (const rec of records) {
+          resultMap.set(rec.attributes.referenceId, {
+            id: 'new_' + rec.attributes.referenceId,
+            success: true,
+            errors: [],
+          });
+        }
+        return Promise.resolve(resultMap);
+      });
+
+      await tool.migrate();
+
+      expect(capturedElements).to.have.lengthOf(1);
+      const propertySet = JSON.parse(capturedElements[0].PropertySetConfig);
+      expect(propertySet.remoteOptions).to.deep.equal({ someExisting: 'value' });
+      expect(propertySet.remoteOptions).to.not.have.property('PreHook');
+      expect(propertySet.remoteOptions).to.not.have.property('PostHook');
+
+      createStub.restore();
+      createOneStub.restore();
+    });
+  });
+
+  describe('migrate() with hook registered and PreHook/PostHook already true', () => {
+    it('should preserve PreHook=true and PostHook=true (idempotent)', async () => {
+      const namespace = 'vlocity_ins';
+      const tool = createTool(namespace);
+
+      mockConnection.query.callsFake((soql: string) => {
+        if (soql.includes('CustomClassImplementation__c')) {
+          return Promise.resolve({ totalSize: 1, records: [{ Id: 'hookId001', Name: 'CpqAppHandlerHook' }] });
+        }
+        if (soql.includes('OmniScript__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [
+              {
+                Id: 'osId001',
+                [`${namespace}__Type__c`]: 'TestType',
+                [`${namespace}__SubType__c`]: 'TestSubType',
+                [`${namespace}__Language__c`]: 'English',
+                [`${namespace}__Version__c`]: 1,
+                [`${namespace}__IsActive__c`]: false,
+                [`${namespace}__IsProcedure__c`]: true,
+              },
+            ],
+          });
+        }
+        if (soql.includes('Element__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [createRemoteActionElement(namespace, { PreHook: true, PostHook: true })],
+          });
+        }
+        if (soql.includes('OmniScriptDefinition__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      });
+
+      const { NetUtils } = require('../../src/utils/net');
+      const createStub = sandbox.stub(NetUtils, 'create');
+      const createOneStub = sandbox.stub(NetUtils, 'createOne');
+
+      createOneStub.resolves({
+        id: 'newOsId001',
+        success: true,
+        errors: [],
+        warnings: [],
+      });
+
+      let capturedElements: any[] = [];
+      createStub.callsFake((_conn: any, objectName: string, records: any[]) => {
+        if (objectName === 'OmniProcessElement') {
+          capturedElements = records;
+        }
+        const resultMap = new Map();
+        for (const rec of records) {
+          resultMap.set(rec.attributes.referenceId, {
+            id: 'new_' + rec.attributes.referenceId,
+            success: true,
+            errors: [],
+          });
+        }
+        return Promise.resolve(resultMap);
+      });
+
+      await tool.migrate();
+
+      expect(capturedElements).to.have.lengthOf(1);
+      const propertySet = JSON.parse(capturedElements[0].PropertySetConfig);
+      expect(propertySet.remoteOptions.PreHook).to.equal(true);
+      expect(propertySet.remoteOptions.PostHook).to.equal(true);
+
+      createStub.restore();
+      createOneStub.restore();
+    });
+  });
+
+  describe('migrate() with non-Remote-Action element type', () => {
+    it('should not add PreHook/PostHook to non-Remote-Action elements', async () => {
+      const namespace = 'vlocity_ins';
+      const tool = createTool(namespace);
+
+      mockConnection.query.callsFake((soql: string) => {
+        if (soql.includes('CustomClassImplementation__c')) {
+          return Promise.resolve({ totalSize: 1, records: [{ Id: 'hookId001', Name: 'CpqAppHandlerHook' }] });
+        }
+        if (soql.includes('OmniScript__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [
+              {
+                Id: 'osId001',
+                [`${namespace}__Type__c`]: 'TestType',
+                [`${namespace}__SubType__c`]: 'TestSubType',
+                [`${namespace}__Language__c`]: 'English',
+                [`${namespace}__Version__c`]: 1,
+                [`${namespace}__IsActive__c`]: false,
+                [`${namespace}__IsProcedure__c`]: true,
+              },
+            ],
+          });
+        }
+        if (soql.includes('Element__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [createNonRemoteActionElement(namespace, 'DataRaptor Extract Action')],
+          });
+        }
+        if (soql.includes('OmniScriptDefinition__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      });
+
+      const { NetUtils } = require('../../src/utils/net');
+      const createStub = sandbox.stub(NetUtils, 'create');
+      const createOneStub = sandbox.stub(NetUtils, 'createOne');
+
+      createOneStub.resolves({
+        id: 'newOsId001',
+        success: true,
+        errors: [],
+        warnings: [],
+      });
+
+      let capturedElements: any[] = [];
+      createStub.callsFake((_conn: any, objectName: string, records: any[]) => {
+        if (objectName === 'OmniProcessElement') {
+          capturedElements = records;
+        }
+        const resultMap = new Map();
+        for (const rec of records) {
+          resultMap.set(rec.attributes.referenceId, {
+            id: 'new_' + rec.attributes.referenceId,
+            success: true,
+            errors: [],
+          });
+        }
+        return Promise.resolve(resultMap);
+      });
+
+      await tool.migrate();
+
+      expect(capturedElements).to.have.lengthOf(1);
+      const propertySet = JSON.parse(capturedElements[0].PropertySetConfig);
+      expect(propertySet.remoteOptions).to.not.have.property('PreHook');
+      expect(propertySet.remoteOptions).to.not.have.property('PostHook');
+
+      createStub.restore();
+      createOneStub.restore();
+    });
+  });
+
+  describe('migrate() when CustomClassImplementation__c query fails', () => {
+    it('should default to false and not set hooks', async () => {
+      const namespace = 'vlocity_ins';
+      const tool = createTool(namespace);
+
+      mockConnection.query.callsFake((soql: string) => {
+        if (soql.includes('CustomClassImplementation__c')) {
+          return Promise.reject(new Error('INVALID_TYPE: sObject type not found'));
+        }
+        if (soql.includes('OmniScript__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [
+              {
+                Id: 'osId001',
+                [`${namespace}__Type__c`]: 'TestType',
+                [`${namespace}__SubType__c`]: 'TestSubType',
+                [`${namespace}__Language__c`]: 'English',
+                [`${namespace}__Version__c`]: 1,
+                [`${namespace}__IsActive__c`]: false,
+                [`${namespace}__IsProcedure__c`]: true,
+              },
+            ],
+          });
+        }
+        if (soql.includes('Element__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [createRemoteActionElement(namespace)],
+          });
+        }
+        if (soql.includes('OmniScriptDefinition__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      });
+
+      const { NetUtils } = require('../../src/utils/net');
+      const createStub = sandbox.stub(NetUtils, 'create');
+      const createOneStub = sandbox.stub(NetUtils, 'createOne');
+
+      createOneStub.resolves({
+        id: 'newOsId001',
+        success: true,
+        errors: [],
+        warnings: [],
+      });
+
+      let capturedElements: any[] = [];
+      createStub.callsFake((_conn: any, objectName: string, records: any[]) => {
+        if (objectName === 'OmniProcessElement') {
+          capturedElements = records;
+        }
+        const resultMap = new Map();
+        for (const rec of records) {
+          resultMap.set(rec.attributes.referenceId, {
+            id: 'new_' + rec.attributes.referenceId,
+            success: true,
+            errors: [],
+          });
+        }
+        return Promise.resolve(resultMap);
+      });
+
+      await tool.migrate();
+
+      expect(mockLogger.warn.calledOnce).to.equal(true);
+      expect(capturedElements).to.have.lengthOf(1);
+      const propertySet = JSON.parse(capturedElements[0].PropertySetConfig);
+      expect(propertySet.remoteOptions).to.not.have.property('PreHook');
+      expect(propertySet.remoteOptions).to.not.have.property('PostHook');
+
+      createStub.restore();
+      createOneStub.restore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
When migrating Integration Procedures from managed-package runtime to Core standard runtime, customers silently lose their custom pre/post hook logic because the new PreHook/PostHook booleans default to false. This PR patches the migration tool to detect registered CpqAppHandlerHook implementations in the source org and auto-enable both flags on every migrated Remote Action step, preserving managed-package parity without manual intervention.

## 🔍 Root Cause Analysis

**Problem:** Customers with a CpqAppHandlerHook registered in CustomClassImplementation__c lose hook execution after IP migration because the Core standard runtime requires explicit opt-in via PreHook/PostHook boolean flags on each Remote Action step's remoteOptions, whereas the managed-package runtime fired hooks automatically whenever a hook was registered.

**Primary cause:** The migration script did not inspect the source org's hook registrations or set the corresponding Core-side flags during element migration.

**Secondary cause:** The Core-side PreHook/PostHook fields intentionally default to false for greenfield IPs (correct for new development, incorrect for migrated IPs that relied on implicit hook behavior).

**Severity:** High - Migrated customers silently lose business-critical hook logic (CPQ pricing, validation, enrichment) with no runtime error, only incorrect behavior.

## 🔧 Solution

- Added `checkCpqAppHandlerHook()` method that queries `{namespace}__CustomClassImplementation__c` for a `CpqAppHandlerHook` record in the source org, cached once per migration run
- Added `case 'Remote Action':` to the `mapElementData` switch that sets `remoteOptions.PreHook = true` and `remoteOptions.PostHook = true` when the hook is registered
- Query failure (permission issues, missing object) gracefully defaults to `false` with a warning log — migration continues without setting hooks rather than aborting
- The hook check runs once in `migrate()` before the element processing loop (not per-element), stored in `this.hasCpqAppHandlerHook`
- The new case mutates the already-parsed `propertySet` object in place; the existing `JSON.stringify` after the switch handles serialization

**Files changed:**
- `src/migration/omniscript.ts`
- `test/migration/omniscript.test.ts` (new)

## 🧪 Testing

Added 5 Mocha test scenarios covering:
1. Hook registered → PreHook=true, PostHook=true set on Remote Action elements
2. No hook registered → remoteOptions unchanged (no keys added)
3. Flags already true + hook registered → values preserved (idempotent)
4. Non-Remote-Action element type → not affected by this change
5. CustomClassImplementation__c query failure → defaults to false, logs warning, migration continues

Static analysis: ESLint PASSED (pre-existing warning in unrelated file only), TypeScript `tsc --noEmit` PASSED

## Impact Assessment

- **Breaking changes:** None — existing migration behavior for all non-Remote-Action element types is unchanged
- **Performance impact:** One additional SOQL query per migration run (cached result), negligible
- **Related WIs:** W-22403162 (this story), TD-0271459 (parent initiative), W-22202779–W-22202839 (Core-side PreHook/PostHook implementation)