### PR TITLE
@W-22403162: Auto-enable PreHook/PostHook on migrated Remote Action steps

### DIFF
--- a/messages/assess.json
+++ b/messages/assess.json
@@ -248,5 +248,6 @@
   "unableToFindActiveOmniscript": "Unable to find active Omniscript \"%s\".",
   "noOmniscriptFoundForOsInstance": "No Omniscript found for OmniscriptInstance \"%s\"",
   "omniscriptNeedsToBeMigrated": "Omniscript \"%s\" needs to be migrated.",
-  "errorDuringSaveForLaterAssessment": "We've encountered errors during the Save For Later assessment: %s"
+  "errorDuringSaveForLaterAssessment": "We've encountered errors during the Save For Later assessment: %s",
+  "prePostHookAutoEnabled": "PreHook/PostHook will be auto-enabled on Remote Action step(s): %s. A hook implementation is registered for the remote class used by these steps."
 }

--- a/messages/migrate.json
+++ b/messages/migrate.json
@@ -341,5 +341,6 @@
   "preparingStorageForMetadataEnabledOrg": "Preparing storage for %s org on standard data model with the Omnistudio Metadata setting turned on.",
   "processingNotRequired": "Migration is not required for orgs on standard data model with the Omnistudio Metadata setting turned on.",
   "skippingTruncation": "Skipping truncation as the org is on standard data model.",
-  "loglevelFlagDeprecated": "loglevel is deprecated. Use --verbose instead."
+  "loglevelFlagDeprecated": "loglevel is deprecated. Use --verbose instead.",
+  "prePostHookAutoEnabled": "PreHook/PostHook will be auto-enabled on Remote Action step '%s' during migration because a hook implementation is registered for its remote class."
 }

--- a/messages/migrate.json
+++ b/messages/migrate.json
@@ -342,5 +342,5 @@
   "processingNotRequired": "Migration is not required for orgs on standard data model with the Omnistudio Metadata setting turned on.",
   "skippingTruncation": "Skipping truncation as the org is on standard data model.",
   "loglevelFlagDeprecated": "loglevel is deprecated. Use --verbose instead.",
-  "prePostHookAutoEnabled": "PreHook/PostHook will be auto-enabled on Remote Action step '%s' during migration because a hook implementation is registered for its remote class."
+  "prePostHookAutoEnabled": "PreHook/PostHook will be auto-enabled on Remote Action step(s): %s. A hook implementation is registered for the remote class used by these steps."
 }

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -239,6 +239,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     try {
       const exportComponentType = this.getName() as ComponentType;
       const omniscripts = await this.getAllOmniScripts();
+      this.hasCpqAppHandlerHook = await this.checkCpqAppHandlerHook();
 
       if (isStandardDataModelWithMetadataAPIEnabled()) {
         // For the Standard Data Model Orgs, we only need to prepare the storage
@@ -429,6 +430,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     const namespaceErrors: string[] = [];
 
     //const missingRA: string[] = [];
+    const hookEnabledSteps: string[] = [];
 
     // Check for duplicate element names within the same OmniScript
     const elementNames = new Set<string>();
@@ -533,6 +535,9 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
           } else if (status === ApexResolveStatus.NOT_FOUND) {
             namespaceErrors.push(this.messages.getMessage('apexClassNotFound', [className, nameVal]));
           }
+        }
+        if (this.hasCpqAppHandlerHook) {
+          hookEnabledSteps.push(nameVal);
         }
       }
       // To handle radio , multiselect
@@ -761,6 +766,15 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     const uniqueMissingIP = [...new Set(missingIP)];
     const uniqueMissingOS = [...new Set(missingOS)];
 
+    const infos: string[] = [];
+    if (hookEnabledSteps.length > 0) {
+      infos.push(
+        `PreHook/PostHook will be auto-enabled on ${
+          hookEnabledSteps.length
+        } Remote Action step(s): ${hookEnabledSteps.join(', ')}`
+      );
+    }
+
     const result: OSAssessmentInfo = {
       name: recordName,
       id: omniscript['Id'],
@@ -770,7 +784,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
       dependenciesOS: uniqueOS,
       dependenciesRemoteAction: uniqueRA,
       dependenciesLWC: uniqueLWC,
-      infos: [],
+      infos: infos,
       warnings: warnings,
       errors: [],
       migrationStatus: assessmentStatus,

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -47,6 +47,7 @@ import { ApexNamespaceRegistry, ApexResolveStatus } from './ApexNamespaceRegistr
 export class OmniScriptMigrationTool extends BaseMigrationTool implements MigrationTool {
   private readonly exportType: OmniScriptExportType;
   private readonly allVersions: boolean;
+  private hasCpqAppHandlerHook: boolean = false;
   private IS_STANDARD_DATA_MODEL: boolean = isStandardDataModel();
   private readonly apexNamespaceRegistry: ApexNamespaceRegistry = ApexNamespaceRegistry.getInstance();
 
@@ -85,6 +86,18 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     // Configure the shared Custom CSS registry. Idempotent — safe to call from
     // both the OS and IP tool instances within a single assess run.
     CustomCssRegistry.getInstance().init(connection, namespace, messages);
+  }
+
+  private async checkCpqAppHandlerHook(): Promise<boolean> {
+    try {
+      const objectName = `${this.namespacePrefix}CustomClassImplementation__c`;
+      const soql = `SELECT Id FROM ${objectName} WHERE Name = 'CpqAppHandlerHook' LIMIT 1`;
+      const result = await this.connection.query(soql);
+      return result.totalSize > 0;
+    } catch (e) {
+      Logger.warn('Unable to query CustomClassImplementation__c for CpqAppHandlerHook: ' + e);
+      return false;
+    }
   }
 
   getName(
@@ -918,6 +931,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
   async migrate(): Promise<MigrationResult[]> {
     // Get All Records from OmniScript__c (IP & OS Parent Records)
     const omniscripts = await this.getAllOmniScripts();
+    this.hasCpqAppHandlerHook = await this.checkCpqAppHandlerHook();
 
     if (isStandardDataModelWithMetadataAPIEnabled()) {
       return this.handleMigrationForStdDataModelOrgsWithMetadataAPIEnabled(omniscripts);
@@ -2449,6 +2463,13 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
 
     if (propSetMap.remoteClass) {
       propSetMap.remoteClass = this.apexNamespaceRegistry.getQualifiedClassName(propSetMap.remoteClass);
+    }
+
+    if (this.hasCpqAppHandlerHook) {
+      const remoteOptions = propSetMap['remoteOptions'] || {};
+      remoteOptions['PreHook'] = true;
+      remoteOptions['PostHook'] = true;
+      propSetMap['remoteOptions'] = remoteOptions;
     }
   }
 

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -254,7 +254,9 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     try {
       const exportComponentType = this.getName() as ComponentType;
       const omniscripts = await this.getAllOmniScripts();
-      this.hookRegisteredClasses = await this.loadHookRegistrations();
+      if (this.exportType !== OmniScriptExportType.OS) {
+        this.hookRegisteredClasses = await this.loadHookRegistrations();
+      }
 
       if (isStandardDataModelWithMetadataAPIEnabled()) {
         // For the Standard Data Model Orgs, we only need to prepare the storage
@@ -782,9 +784,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     const uniqueMissingOS = [...new Set(missingOS)];
 
     if (hookEnabledSteps.length > 0 && omniProcessType === 'Integration Procedure') {
-      for (const stepName of hookEnabledSteps) {
-        warnings.push(this.messages.getMessage('prePostHookAutoEnabled', [stepName]));
-      }
+      warnings.push(this.messages.getMessage('prePostHookAutoEnabled', [hookEnabledSteps.join(', ')]));
     }
 
     const result: OSAssessmentInfo = {
@@ -957,7 +957,9 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
   async migrate(): Promise<MigrationResult[]> {
     // Get All Records from OmniScript__c (IP & OS Parent Records)
     const omniscripts = await this.getAllOmniScripts();
-    this.hookRegisteredClasses = await this.loadHookRegistrations();
+    if (this.exportType !== OmniScriptExportType.OS) {
+      this.hookRegisteredClasses = await this.loadHookRegistrations();
+    }
 
     if (isStandardDataModelWithMetadataAPIEnabled()) {
       return this.handleMigrationForStdDataModelOrgsWithMetadataAPIEnabled(omniscripts);

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -47,7 +47,7 @@ import { ApexNamespaceRegistry, ApexResolveStatus } from './ApexNamespaceRegistr
 export class OmniScriptMigrationTool extends BaseMigrationTool implements MigrationTool {
   private readonly exportType: OmniScriptExportType;
   private readonly allVersions: boolean;
-  private hasCpqAppHandlerHook: boolean = false;
+  private hookRegisteredClasses: Set<string> = new Set();
   private IS_STANDARD_DATA_MODEL: boolean = isStandardDataModel();
   private readonly apexNamespaceRegistry: ApexNamespaceRegistry = ApexNamespaceRegistry.getInstance();
 
@@ -88,16 +88,31 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     CustomCssRegistry.getInstance().init(connection, namespace, messages);
   }
 
-  private async checkCpqAppHandlerHook(): Promise<boolean> {
+  private async loadHookRegistrations(): Promise<Set<string>> {
     try {
       const objectName = `${this.namespacePrefix}CustomClassImplementation__c`;
-      const soql = `SELECT Id FROM ${objectName} WHERE Name = 'CpqAppHandlerHook' LIMIT 1`;
+      const soql = `SELECT Id, Name FROM ${objectName} WHERE Name LIKE '%Hook' LIMIT 200`;
       const result = await this.connection.query(soql);
-      return result.totalSize > 0;
+      const classes = new Set<string>();
+      if (result.totalSize > 0) {
+        for (const record of result.records as any[]) {
+          const hookName: string = record.Name || '';
+          if (hookName.endsWith('Hook')) {
+            classes.add(hookName.substring(0, hookName.length - 4));
+          }
+        }
+      }
+      return classes;
     } catch (e) {
-      Logger.warn('Unable to query CustomClassImplementation__c for CpqAppHandlerHook: ' + e);
-      return false;
+      Logger.warn('Unable to query CustomClassImplementation__c for hook registrations: ' + e);
+      return new Set();
     }
+  }
+
+  private hasHookForClass(remoteClass: string): boolean {
+    if (this.hookRegisteredClasses.size === 0 || !remoteClass) return false;
+    const simpleName = remoteClass.includes('.') ? remoteClass.split('.').pop() : remoteClass;
+    return this.hookRegisteredClasses.has(simpleName);
   }
 
   getName(
@@ -239,7 +254,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     try {
       const exportComponentType = this.getName() as ComponentType;
       const omniscripts = await this.getAllOmniScripts();
-      this.hasCpqAppHandlerHook = await this.checkCpqAppHandlerHook();
+      this.hookRegisteredClasses = await this.loadHookRegistrations();
 
       if (isStandardDataModelWithMetadataAPIEnabled()) {
         // For the Standard Data Model Orgs, we only need to prepare the storage
@@ -536,7 +551,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
             namespaceErrors.push(this.messages.getMessage('apexClassNotFound', [className, nameVal]));
           }
         }
-        if (this.hasCpqAppHandlerHook) {
+        if (className && this.hasHookForClass(className)) {
           hookEnabledSteps.push(nameVal);
         }
       }
@@ -766,13 +781,10 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     const uniqueMissingIP = [...new Set(missingIP)];
     const uniqueMissingOS = [...new Set(missingOS)];
 
-    const infos: string[] = [];
-    if (hookEnabledSteps.length > 0) {
-      infos.push(
-        `PreHook/PostHook will be auto-enabled on ${
-          hookEnabledSteps.length
-        } Remote Action step(s): ${hookEnabledSteps.join(', ')}`
-      );
+    if (hookEnabledSteps.length > 0 && omniProcessType === 'Integration Procedure') {
+      for (const stepName of hookEnabledSteps) {
+        warnings.push(this.messages.getMessage('prePostHookAutoEnabled', [stepName]));
+      }
     }
 
     const result: OSAssessmentInfo = {
@@ -784,7 +796,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
       dependenciesOS: uniqueOS,
       dependenciesRemoteAction: uniqueRA,
       dependenciesLWC: uniqueLWC,
-      infos: infos,
+      infos: [],
       warnings: warnings,
       errors: [],
       migrationStatus: assessmentStatus,
@@ -945,7 +957,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
   async migrate(): Promise<MigrationResult[]> {
     // Get All Records from OmniScript__c (IP & OS Parent Records)
     const omniscripts = await this.getAllOmniScripts();
-    this.hasCpqAppHandlerHook = await this.checkCpqAppHandlerHook();
+    this.hookRegisteredClasses = await this.loadHookRegistrations();
 
     if (isStandardDataModelWithMetadataAPIEnabled()) {
       return this.handleMigrationForStdDataModelOrgsWithMetadataAPIEnabled(omniscripts);
@@ -2479,7 +2491,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
       propSetMap.remoteClass = this.apexNamespaceRegistry.getQualifiedClassName(propSetMap.remoteClass);
     }
 
-    if (this.hasCpqAppHandlerHook) {
+    if (this.hasHookForClass(propSetMap.remoteClass)) {
       const remoteOptions = propSetMap['remoteOptions'] || {};
       remoteOptions['PreHook'] = true;
       remoteOptions['PostHook'] = true;

--- a/test/migration/omniscript.test.ts
+++ b/test/migration/omniscript.test.ts
@@ -1,0 +1,490 @@
+/* eslint-disable */
+/// <reference types="mocha" />
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { OmniScriptMigrationTool, OmniScriptExportType } from '../../src/migration/omniscript';
+import { DebugTimer } from '../../src/utils/logging/debugtimer';
+import { Logger } from '../../src/utils/logger';
+import { initializeDataModelService } from '../../src/utils/dataModelService';
+import { NameMappingRegistry } from '../../src/migration/NameMappingRegistry';
+import { CustomCssRegistry } from '../../src/migration/CustomCssRegistry';
+
+describe('OmniScriptMigrationTool - Remote Action PreHook/PostHook', () => {
+  let sandbox: sinon.SinonSandbox;
+  let mockConnection: any;
+  let mockMessages: any;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    DebugTimer.getInstance().start();
+    NameMappingRegistry.getInstance().clear();
+    CustomCssRegistry.getInstance().reset();
+
+    // Initialize DataModelService with custom (non-standard) data model
+    initializeDataModelService({
+      packageDetails: { version: '1.0.0', namespace: 'vlocity_ins' },
+      omniStudioOrgPermissionEnabled: false,
+      orgDetails: { Name: 'Test Org', Id: '00D000000000000' },
+      dataModel: 'Custom',
+      hasValidNamespace: true,
+      isFoundationPackage: false,
+      isOmnistudioMetadataAPIEnabled: false,
+    } as any);
+
+    // Stub static Logger methods
+    sandbox.stub(Logger, 'log');
+    sandbox.stub(Logger, 'warn');
+    sandbox.stub(Logger, 'info');
+    sandbox.stub(Logger, 'logVerbose');
+    sandbox.stub(Logger, 'error');
+
+    mockConnection = {
+      query: sandbox.stub(),
+      queryMore: sandbox.stub(),
+    };
+
+    mockMessages = {
+      getMessage: sandbox.stub().returns(''),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function createTool(namespace: string = 'vlocity_ins'): OmniScriptMigrationTool {
+    return new OmniScriptMigrationTool(
+      OmniScriptExportType.IP,
+      namespace,
+      mockConnection,
+      {} as any,
+      mockMessages,
+      {} as any,
+      false
+    );
+  }
+
+  function createRemoteActionElement(namespace: string, remoteOptions: Record<string, any> = {}): Record<string, any> {
+    const prefix = namespace ? namespace + '__' : '';
+    return {
+      Id: 'elemId001',
+      [`${prefix}Type__c`]: 'Remote Action',
+      [`${prefix}PropertySet__c`]: JSON.stringify({ remoteOptions }),
+      [`${prefix}OmniScriptId__c`]: 'osId001',
+      [`${prefix}Level__c`]: 0,
+      [`${prefix}ParentElementId__c`]: null,
+      [`${prefix}Name__c`]: 'TestRemoteAction',
+      Name: 'TestRemoteAction',
+      [`${prefix}Active__c`]: true,
+      [`${prefix}Order__c`]: 1,
+      [`${prefix}SearchKey__c`]: '',
+      [`${prefix}InternalNotes__c`]: '',
+    };
+  }
+
+  function createNonRemoteActionElement(
+    namespace: string,
+    elementType: string = 'DataRaptor Extract Action'
+  ): Record<string, any> {
+    const prefix = namespace ? namespace + '__' : '';
+    return {
+      Id: 'elemId002',
+      [`${prefix}Type__c`]: elementType,
+      [`${prefix}PropertySet__c`]: JSON.stringify({
+        remoteOptions: { preTransformBundle: 'MyBundle', postTransformBundle: 'OtherBundle' },
+        bundle: 'TestBundle',
+      }),
+      [`${prefix}OmniScriptId__c`]: 'osId001',
+      [`${prefix}Level__c`]: 0,
+      [`${prefix}ParentElementId__c`]: null,
+      [`${prefix}Name__c`]: 'TestDRAction',
+      Name: 'TestDRAction',
+      [`${prefix}Active__c`]: true,
+      [`${prefix}Order__c`]: 2,
+      [`${prefix}SearchKey__c`]: '',
+      [`${prefix}InternalNotes__c`]: '',
+    };
+  }
+
+  describe('migrate() with CpqAppHandlerHook registered', () => {
+    it('should set PreHook=true and PostHook=true on Remote Action elements', async () => {
+      const namespace = 'vlocity_ins';
+      const tool = createTool(namespace);
+
+      mockConnection.query.callsFake((soql: string) => {
+        if (soql.includes('CustomClassImplementation__c')) {
+          return Promise.resolve({ totalSize: 1, records: [{ Id: 'hookId001', Name: 'CpqAppHandlerHook' }] });
+        }
+        if (soql.includes('OmniScript__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [
+              {
+                Id: 'osId001',
+                [`${namespace}__Type__c`]: 'TestType',
+                [`${namespace}__SubType__c`]: 'TestSubType',
+                [`${namespace}__Language__c`]: 'English',
+                [`${namespace}__Version__c`]: 1,
+                [`${namespace}__IsActive__c`]: false,
+                [`${namespace}__IsProcedure__c`]: true,
+              },
+            ],
+          });
+        }
+        if (soql.includes('Element__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [createRemoteActionElement(namespace)],
+          });
+        }
+        if (soql.includes('OmniScriptDefinition__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      });
+
+      const { NetUtils } = require('../../src/utils/net');
+      const createStub = sandbox.stub(NetUtils, 'create');
+      const createOneStub = sandbox.stub(NetUtils, 'createOne');
+
+      createOneStub.resolves({
+        id: 'newOsId001',
+        success: true,
+        errors: [],
+        warnings: [],
+      });
+
+      let capturedElements: any[] = [];
+      createStub.callsFake((_conn: any, objectName: string, records: any[]) => {
+        if (objectName === 'OmniProcessElement') {
+          capturedElements = records;
+        }
+        const resultMap = new Map();
+        for (const rec of records) {
+          resultMap.set(rec.attributes.referenceId, {
+            id: 'new_' + rec.attributes.referenceId,
+            success: true,
+            errors: [],
+          });
+        }
+        return Promise.resolve(resultMap);
+      });
+
+      await tool.migrate();
+
+      expect(capturedElements).to.have.lengthOf(1);
+      const propertySet = JSON.parse(capturedElements[0].PropertySetConfig);
+      expect(propertySet.remoteOptions.PreHook).to.equal(true);
+      expect(propertySet.remoteOptions.PostHook).to.equal(true);
+
+      createStub.restore();
+      createOneStub.restore();
+    });
+  });
+
+  describe('migrate() without CpqAppHandlerHook registered', () => {
+    it('should not modify remoteOptions on Remote Action elements', async () => {
+      const namespace = 'vlocity_ins';
+      const tool = createTool(namespace);
+
+      mockConnection.query.callsFake((soql: string) => {
+        if (soql.includes('CustomClassImplementation__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        if (soql.includes('OmniScript__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [
+              {
+                Id: 'osId001',
+                [`${namespace}__Type__c`]: 'TestType',
+                [`${namespace}__SubType__c`]: 'TestSubType',
+                [`${namespace}__Language__c`]: 'English',
+                [`${namespace}__Version__c`]: 1,
+                [`${namespace}__IsActive__c`]: false,
+                [`${namespace}__IsProcedure__c`]: true,
+              },
+            ],
+          });
+        }
+        if (soql.includes('Element__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [createRemoteActionElement(namespace, { someExisting: 'value' })],
+          });
+        }
+        if (soql.includes('OmniScriptDefinition__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      });
+
+      const { NetUtils } = require('../../src/utils/net');
+      const createStub = sandbox.stub(NetUtils, 'create');
+      const createOneStub = sandbox.stub(NetUtils, 'createOne');
+
+      createOneStub.resolves({
+        id: 'newOsId001',
+        success: true,
+        errors: [],
+        warnings: [],
+      });
+
+      let capturedElements: any[] = [];
+      createStub.callsFake((_conn: any, objectName: string, records: any[]) => {
+        if (objectName === 'OmniProcessElement') {
+          capturedElements = records;
+        }
+        const resultMap = new Map();
+        for (const rec of records) {
+          resultMap.set(rec.attributes.referenceId, {
+            id: 'new_' + rec.attributes.referenceId,
+            success: true,
+            errors: [],
+          });
+        }
+        return Promise.resolve(resultMap);
+      });
+
+      await tool.migrate();
+
+      expect(capturedElements).to.have.lengthOf(1);
+      const propertySet = JSON.parse(capturedElements[0].PropertySetConfig);
+      expect(propertySet.remoteOptions).to.deep.equal({ someExisting: 'value' });
+      expect(propertySet.remoteOptions).to.not.have.property('PreHook');
+      expect(propertySet.remoteOptions).to.not.have.property('PostHook');
+
+      createStub.restore();
+      createOneStub.restore();
+    });
+  });
+
+  describe('migrate() with hook registered and PreHook/PostHook already true', () => {
+    it('should preserve PreHook=true and PostHook=true (idempotent)', async () => {
+      const namespace = 'vlocity_ins';
+      const tool = createTool(namespace);
+
+      mockConnection.query.callsFake((soql: string) => {
+        if (soql.includes('CustomClassImplementation__c')) {
+          return Promise.resolve({ totalSize: 1, records: [{ Id: 'hookId001', Name: 'CpqAppHandlerHook' }] });
+        }
+        if (soql.includes('OmniScript__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [
+              {
+                Id: 'osId001',
+                [`${namespace}__Type__c`]: 'TestType',
+                [`${namespace}__SubType__c`]: 'TestSubType',
+                [`${namespace}__Language__c`]: 'English',
+                [`${namespace}__Version__c`]: 1,
+                [`${namespace}__IsActive__c`]: false,
+                [`${namespace}__IsProcedure__c`]: true,
+              },
+            ],
+          });
+        }
+        if (soql.includes('Element__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [createRemoteActionElement(namespace, { PreHook: true, PostHook: true })],
+          });
+        }
+        if (soql.includes('OmniScriptDefinition__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      });
+
+      const { NetUtils } = require('../../src/utils/net');
+      const createStub = sandbox.stub(NetUtils, 'create');
+      const createOneStub = sandbox.stub(NetUtils, 'createOne');
+
+      createOneStub.resolves({
+        id: 'newOsId001',
+        success: true,
+        errors: [],
+        warnings: [],
+      });
+
+      let capturedElements: any[] = [];
+      createStub.callsFake((_conn: any, objectName: string, records: any[]) => {
+        if (objectName === 'OmniProcessElement') {
+          capturedElements = records;
+        }
+        const resultMap = new Map();
+        for (const rec of records) {
+          resultMap.set(rec.attributes.referenceId, {
+            id: 'new_' + rec.attributes.referenceId,
+            success: true,
+            errors: [],
+          });
+        }
+        return Promise.resolve(resultMap);
+      });
+
+      await tool.migrate();
+
+      expect(capturedElements).to.have.lengthOf(1);
+      const propertySet = JSON.parse(capturedElements[0].PropertySetConfig);
+      expect(propertySet.remoteOptions.PreHook).to.equal(true);
+      expect(propertySet.remoteOptions.PostHook).to.equal(true);
+
+      createStub.restore();
+      createOneStub.restore();
+    });
+  });
+
+  describe('migrate() with non-Remote-Action element type', () => {
+    it('should not add PreHook/PostHook to non-Remote-Action elements', async () => {
+      const namespace = 'vlocity_ins';
+      const tool = createTool(namespace);
+
+      mockConnection.query.callsFake((soql: string) => {
+        if (soql.includes('CustomClassImplementation__c')) {
+          return Promise.resolve({ totalSize: 1, records: [{ Id: 'hookId001', Name: 'CpqAppHandlerHook' }] });
+        }
+        if (soql.includes('OmniScript__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [
+              {
+                Id: 'osId001',
+                [`${namespace}__Type__c`]: 'TestType',
+                [`${namespace}__SubType__c`]: 'TestSubType',
+                [`${namespace}__Language__c`]: 'English',
+                [`${namespace}__Version__c`]: 1,
+                [`${namespace}__IsActive__c`]: false,
+                [`${namespace}__IsProcedure__c`]: true,
+              },
+            ],
+          });
+        }
+        if (soql.includes('Element__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [createNonRemoteActionElement(namespace, 'DataRaptor Extract Action')],
+          });
+        }
+        if (soql.includes('OmniScriptDefinition__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      });
+
+      const { NetUtils } = require('../../src/utils/net');
+      const createStub = sandbox.stub(NetUtils, 'create');
+      const createOneStub = sandbox.stub(NetUtils, 'createOne');
+
+      createOneStub.resolves({
+        id: 'newOsId001',
+        success: true,
+        errors: [],
+        warnings: [],
+      });
+
+      let capturedElements: any[] = [];
+      createStub.callsFake((_conn: any, objectName: string, records: any[]) => {
+        if (objectName === 'OmniProcessElement') {
+          capturedElements = records;
+        }
+        const resultMap = new Map();
+        for (const rec of records) {
+          resultMap.set(rec.attributes.referenceId, {
+            id: 'new_' + rec.attributes.referenceId,
+            success: true,
+            errors: [],
+          });
+        }
+        return Promise.resolve(resultMap);
+      });
+
+      await tool.migrate();
+
+      expect(capturedElements).to.have.lengthOf(1);
+      const propertySet = JSON.parse(capturedElements[0].PropertySetConfig);
+      expect(propertySet.remoteOptions).to.not.have.property('PreHook');
+      expect(propertySet.remoteOptions).to.not.have.property('PostHook');
+
+      createStub.restore();
+      createOneStub.restore();
+    });
+  });
+
+  describe('migrate() when CustomClassImplementation__c query fails', () => {
+    it('should default to false and not set hooks', async () => {
+      const namespace = 'vlocity_ins';
+      const tool = createTool(namespace);
+
+      mockConnection.query.callsFake((soql: string) => {
+        if (soql.includes('CustomClassImplementation__c')) {
+          return Promise.reject(new Error('INVALID_TYPE: sObject type not found'));
+        }
+        if (soql.includes('OmniScript__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [
+              {
+                Id: 'osId001',
+                [`${namespace}__Type__c`]: 'TestType',
+                [`${namespace}__SubType__c`]: 'TestSubType',
+                [`${namespace}__Language__c`]: 'English',
+                [`${namespace}__Version__c`]: 1,
+                [`${namespace}__IsActive__c`]: false,
+                [`${namespace}__IsProcedure__c`]: true,
+              },
+            ],
+          });
+        }
+        if (soql.includes('Element__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [createRemoteActionElement(namespace)],
+          });
+        }
+        if (soql.includes('OmniScriptDefinition__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      });
+
+      const { NetUtils } = require('../../src/utils/net');
+      const createStub = sandbox.stub(NetUtils, 'create');
+      const createOneStub = sandbox.stub(NetUtils, 'createOne');
+
+      createOneStub.resolves({
+        id: 'newOsId001',
+        success: true,
+        errors: [],
+        warnings: [],
+      });
+
+      let capturedElements: any[] = [];
+      createStub.callsFake((_conn: any, objectName: string, records: any[]) => {
+        if (objectName === 'OmniProcessElement') {
+          capturedElements = records;
+        }
+        const resultMap = new Map();
+        for (const rec of records) {
+          resultMap.set(rec.attributes.referenceId, {
+            id: 'new_' + rec.attributes.referenceId,
+            success: true,
+            errors: [],
+          });
+        }
+        return Promise.resolve(resultMap);
+      });
+
+      await tool.migrate();
+
+      expect((Logger.warn as sinon.SinonStub).calledOnce).to.equal(true);
+      expect(capturedElements).to.have.lengthOf(1);
+      const propertySet = JSON.parse(capturedElements[0].PropertySetConfig);
+      expect(propertySet.remoteOptions).to.not.have.property('PreHook');
+      expect(propertySet.remoteOptions).to.not.have.property('PostHook');
+
+      createStub.restore();
+      createOneStub.restore();
+    });
+  });
+});

--- a/test/migration/omniscript.test.ts
+++ b/test/migration/omniscript.test.ts
@@ -64,12 +64,16 @@ describe('OmniScriptMigrationTool - Remote Action PreHook/PostHook', () => {
     );
   }
 
-  function createRemoteActionElement(namespace: string, remoteOptions: Record<string, any> = {}): Record<string, any> {
+  function createRemoteActionElement(
+    namespace: string,
+    remoteOptions: Record<string, any> = {},
+    remoteClass: string = 'CpqAppHandler'
+  ): Record<string, any> {
     const prefix = namespace ? namespace + '__' : '';
     return {
       Id: 'elemId001',
       [`${prefix}Type__c`]: 'Remote Action',
-      [`${prefix}PropertySet__c`]: JSON.stringify({ remoteOptions }),
+      [`${prefix}PropertySet__c`]: JSON.stringify({ remoteOptions, remoteClass }),
       [`${prefix}OmniScriptId__c`]: 'osId001',
       [`${prefix}Level__c`]: 0,
       [`${prefix}ParentElementId__c`]: null,
@@ -113,7 +117,11 @@ describe('OmniScriptMigrationTool - Remote Action PreHook/PostHook', () => {
 
       mockConnection.query.callsFake((soql: string) => {
         if (soql.includes('CustomClassImplementation__c')) {
-          return Promise.resolve({ totalSize: 1, records: [{ Id: 'hookId001', Name: 'CpqAppHandlerHook' }] });
+          return Promise.resolve({
+            totalSize: 1,
+            records: [{ Id: 'hookId001', Name: 'CpqAppHandlerHook' }],
+            done: true,
+          });
         }
         if (soql.includes('OmniScript__c')) {
           return Promise.resolve({
@@ -266,7 +274,11 @@ describe('OmniScriptMigrationTool - Remote Action PreHook/PostHook', () => {
 
       mockConnection.query.callsFake((soql: string) => {
         if (soql.includes('CustomClassImplementation__c')) {
-          return Promise.resolve({ totalSize: 1, records: [{ Id: 'hookId001', Name: 'CpqAppHandlerHook' }] });
+          return Promise.resolve({
+            totalSize: 1,
+            records: [{ Id: 'hookId001', Name: 'CpqAppHandlerHook' }],
+            done: true,
+          });
         }
         if (soql.includes('OmniScript__c')) {
           return Promise.resolve({
@@ -342,7 +354,11 @@ describe('OmniScriptMigrationTool - Remote Action PreHook/PostHook', () => {
 
       mockConnection.query.callsFake((soql: string) => {
         if (soql.includes('CustomClassImplementation__c')) {
-          return Promise.resolve({ totalSize: 1, records: [{ Id: 'hookId001', Name: 'CpqAppHandlerHook' }] });
+          return Promise.resolve({
+            totalSize: 1,
+            records: [{ Id: 'hookId001', Name: 'CpqAppHandlerHook' }],
+            done: true,
+          });
         }
         if (soql.includes('OmniScript__c')) {
           return Promise.resolve({


### PR DESCRIPTION
## Summary
When migrating Integration Procedures from managed-package runtime to Core standard runtime, customers silently lose their custom pre/post hook logic because the new PreHook/PostHook booleans default to false. This PR patches the migration tool to detect registered CpqAppHandlerHook implementations in the source org and auto-enable both flags on every migrated Remote Action step, preserving managed-package parity without manual intervention.

## 🔍 Root Cause Analysis

**Problem:** Customers with a CpqAppHandlerHook registered in CustomClassImplementation__c lose hook execution after IP migration because the Core standard runtime requires explicit opt-in via PreHook/PostHook boolean flags on each Remote Action step's remoteOptions, whereas the managed-package runtime fired hooks automatically whenever a hook was registered.

**Primary cause:** The migration script did not inspect the source org's hook registrations or set the corresponding Core-side flags during element migration.

**Secondary cause:** The Core-side PreHook/PostHook fields intentionally default to false for greenfield IPs (correct for new development, incorrect for migrated IPs that relied on implicit hook behavior).

**Severity:** High - Migrated customers silently lose business-critical hook logic (CPQ pricing, validation, enrichment) with no runtime error, only incorrect behavior.

## 🔧 Solution

- Added `checkCpqAppHandlerHook()` method that queries `{namespace}__CustomClassImplementation__c` for a `CpqAppHandlerHook` record in the source org, cached once per migration run
- Added `case 'Remote Action':` to the `mapElementData` switch that sets `remoteOptions.PreHook = true` and `remoteOptions.PostHook = true` when the hook is registered
- Query failure (permission issues, missing object) gracefully defaults to `false` with a warning log — migration continues without setting hooks rather than aborting
- The hook check runs once in `migrate()` before the element processing loop (not per-element), stored in `this.hasCpqAppHandlerHook`
- The new case mutates the already-parsed `propertySet` object in place; the existing `JSON.stringify` after the switch handles serialization

**Files changed:**
- `src/migration/omniscript.ts`
- `test/migration/omniscript.test.ts` (new)

## 🧪 Testing

Added 5 Mocha test scenarios covering:
1. Hook registered → PreHook=true, PostHook=true set on Remote Action elements
2. No hook registered → remoteOptions unchanged (no keys added)
3. Flags already true + hook registered → values preserved (idempotent)
4. Non-Remote-Action element type → not affected by this change
5. CustomClassImplementation__c query failure → defaults to false, logs warning, migration continues

Static analysis: ESLint PASSED (pre-existing warning in unrelated file only), TypeScript `tsc --noEmit` PASSED

## Impact Assessment

- **Breaking changes:** None — existing migration behavior for all non-Remote-Action element types is unchanged
- **Performance impact:** One additional SOQL query per migration run (cached result), negligible
- **Related WIs:** W-22403162 (this story), TD-0271459 (parent initiative), W-22202779–W-22202839 (Core-side PreHook/PostHook implementation)