### PR TITLE
@W-22334153 Adding fixes for navigate action in Omniscript

### DIFF
--- a/fetch_titles.js
+++ b/fetch_titles.js
@@ -1,0 +1,28 @@
+const puppeteer = require('puppeteer');
+
+async function getTitle(url) {
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+  });
+  const page = await browser.newPage();
+  try {
+    await page.goto(url, { waitUntil: 'networkidle2', timeout: 60000 });
+    // Try to find article H1
+    const h1 = await page.evaluate(() => {
+      const h1s = document.querySelectorAll('h1');
+      return Array.from(h1s).map(h => h.textContent.trim());
+    });
+    console.log(url);
+    console.log('H1s:', JSON.stringify(h1));
+  } catch (e) {
+    console.log('Error:', e.message);
+  } finally {
+    await browser.close();
+  }
+}
+
+(async () => {
+  await getTitle('https://help.salesforce.com/s/articleView?id=xcloud.os_version_omniscripts.htm&type=5');
+  await getTitle('https://help.salesforce.com/s/articleView?id=xcloud.os_add_an_action_to_a_flexcard_25672.htm&type=5');
+})();

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -2129,6 +2129,9 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
       case Constants.RemoteAction:
         this.processRemoteAction(propSet);
         break;
+      case Constants.NavigateAction:
+        this.processNavigateAction(propSet);
+        break;
       default:
         // Handle other element types if needed
         break;
@@ -2362,6 +2365,46 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
       );
       propSetMap['Type'] = this.cleanName(osType);
       propSetMap['Sub Type'] = this.cleanName(osSubType);
+    }
+  }
+
+  /**
+   * Processes Navigate Action elements so the migrated parent OmniScript can launch its child
+   * under the standard runtime: resolves Type/Sub Type/Language from the legacy `LWC OmniScript`
+   * reference and rewrites `OmniScript Prefill` keys from the managed-package `c__` namespace
+   * to the standard runtime's `omniscript__` namespace.
+   * @param propSetMap Property set map from the element
+   */
+  private processNavigateAction(propSetMap: any): void {
+    const lwcRef: string = typeof propSetMap['LWC OmniScript'] === 'string' ? propSetMap['LWC OmniScript'] : '';
+    if (lwcRef) {
+      const stripped = lwcRef.replace(/^c:/, '').replace(/^c__/, '').toLowerCase();
+      const match = this.nameRegistry.getOmniScriptMappingKeys().find((key) => {
+        const parts = key.split('_');
+        if (parts.length < 2) return false;
+        const type = parts[0];
+        const subType = parts[1];
+        const language = parts[2] || 'English';
+        const candidate = `${this.cleanName(type)}${this.cleanName(subType)}${language}`.toLowerCase();
+        return candidate === stripped;
+      });
+
+      if (match) {
+        const cleanedFullName = this.nameRegistry.getCleanedName(match, 'OmniScript');
+        const cleanedParts = cleanedFullName.split('_');
+        if (cleanedParts.length >= 2) {
+          propSetMap['Type'] = cleanedParts[0];
+          propSetMap['Sub Type'] = cleanedParts[1];
+          propSetMap['Language'] = cleanedParts[2] || match.split('_')[2] || 'English';
+        }
+        propSetMap['LWC OmniScript'] = '';
+      } else {
+        Logger.logVerbose(`\n${this.messages.getMessage('componentMappingNotFound', ['OmniScript', lwcRef])}`);
+      }
+    }
+
+    if (typeof propSetMap['OmniScript Prefill'] === 'string' && propSetMap['OmniScript Prefill']) {
+      propSetMap['OmniScript Prefill'] = propSetMap['OmniScript Prefill'].replace(/(^|&)c__/g, '$1omniscript__');
     }
   }
 

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -2370,16 +2370,27 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
 
   /**
    * Processes Navigate Action elements so the migrated parent OmniScript can launch its child
-   * under the standard runtime: resolves Type/Sub Type/Language from the legacy `LWC OmniScript`
-   * reference and rewrites `OmniScript Prefill` keys from the managed-package `c__` namespace
-   * to the standard runtime's `omniscript__` namespace.
+   * under the standard runtime. The standard-runtime Navigate Action LWC reads
+   * `omniscript__type`, `omniscript__subType`, `omniscript__language` from the propertySet to
+   * resolve the child OmniScript (it does not consume `targetLWC`). Params on the URL bound for
+   * the OmniScript page must use the `omniscript__` prefix instead of the managed-package `c__`
+   * prefix.
    * @param propSetMap Property set map from the element
    */
   private processNavigateAction(propSetMap: any): void {
-    const lwcRef: string = typeof propSetMap['LWC OmniScript'] === 'string' ? propSetMap['LWC OmniScript'] : '';
+    if (propSetMap.targetType !== 'Vlocity OmniScript') {
+      return;
+    }
+
+    const lwcRef: string = typeof propSetMap.targetLWC === 'string' ? propSetMap.targetLWC : '';
     if (lwcRef) {
-      const stripped = lwcRef.replace(/^c:/, '').replace(/^c__/, '').toLowerCase();
-      const match = this.nameRegistry.getOmniScriptMappingKeys().find((key) => {
+      // propertySet stores the LWC tag form ("c:foo" or "c__foo"); the ES-module form ("c/foo")
+      // never appears here, so stripping a leading "<ns>:" or "c__" covers all valid inputs.
+      const stripped = lwcRef
+        .replace(/^[^:]+:/, '')
+        .replace(/^c__/, '')
+        .toLowerCase();
+      const candidates = this.nameRegistry.getOmniScriptMappingKeys().filter((key) => {
         const parts = key.split('_');
         if (parts.length < 2) return false;
         const type = parts[0];
@@ -2389,22 +2400,30 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
         return candidate === stripped;
       });
 
+      if (candidates.length > 1) {
+        Logger.logVerbose(
+          `\nMultiple OmniScript registry keys collapse to the same LWC name '${lwcRef}': ${candidates.join(
+            ', '
+          )}. Using the first match.`
+        );
+      }
+
+      const match = candidates[0];
       if (match) {
         const cleanedFullName = this.nameRegistry.getCleanedName(match, 'OmniScript');
         const cleanedParts = cleanedFullName.split('_');
         if (cleanedParts.length >= 2) {
-          propSetMap['Type'] = cleanedParts[0];
-          propSetMap['Sub Type'] = cleanedParts[1];
-          propSetMap['Language'] = cleanedParts[2] || match.split('_')[2] || 'English';
+          propSetMap.omniscript__type = cleanedParts[0];
+          propSetMap.omniscript__subType = cleanedParts[1];
+          propSetMap.omniscript__language = cleanedParts[2] || match.split('_')[2] || 'English';
         }
-        propSetMap['LWC OmniScript'] = '';
       } else {
         Logger.logVerbose(`\n${this.messages.getMessage('componentMappingNotFound', ['OmniScript', lwcRef])}`);
       }
     }
 
-    if (typeof propSetMap['OmniScript Prefill'] === 'string' && propSetMap['OmniScript Prefill']) {
-      propSetMap['OmniScript Prefill'] = propSetMap['OmniScript Prefill'].replace(/(^|&)c__/g, '$1omniscript__');
+    if (typeof propSetMap.targetLWCParams === 'string' && propSetMap.targetLWCParams) {
+      propSetMap.targetLWCParams = propSetMap.targetLWCParams.replace(/(^|&)c__/g, '$1omniscript__');
     }
   }
 

--- a/test/migration/omniscript-content-processing.test.ts
+++ b/test/migration/omniscript-content-processing.test.ts
@@ -308,6 +308,91 @@ describe('OmniScript Content Processing - Comprehensive Tests', () => {
     });
   });
 
+  describe('Navigate Action Processing', () => {
+    it('should resolve Type/Sub Type/Language from LWC OmniScript reference and clear LWC name', () => {
+      const propSetMap: any = {
+        'LWC OmniScript': 'c:customerprofileEnglish',
+        'OmniScript Prefill': '',
+        'Page Reference Type': 'Vlocity OmniScript',
+      };
+
+      (omniScriptTool as any).processNavigateAction(propSetMap);
+
+      expect(propSetMap.Type).to.equal('Customer');
+      expect(propSetMap['Sub Type']).to.equal('ProfileCleaned');
+      expect(propSetMap.Language).to.equal('English');
+      expect(propSetMap['LWC OmniScript']).to.equal('');
+      expect(propSetMap['Page Reference Type']).to.equal('Vlocity OmniScript');
+    });
+
+    it('should rewrite c__ prefill keys to omniscript__ at key boundaries', () => {
+      const propSetMap: any = {
+        'LWC OmniScript': '',
+        'OmniScript Prefill': 'c__OrderNumber=%OrderNumber%&c__tabLabel=Order Summary&c__tabIcon=standard:orders',
+      };
+
+      (omniScriptTool as any).processNavigateAction(propSetMap);
+
+      expect(propSetMap['OmniScript Prefill']).to.equal(
+        'omniscript__OrderNumber=%OrderNumber%&omniscript__tabLabel=Order Summary&omniscript__tabIcon=standard:orders'
+      );
+    });
+
+    it('should not rewrite c__ substrings inside prefill values', () => {
+      const propSetMap: any = {
+        'LWC OmniScript': '',
+        'OmniScript Prefill': 'c__foo=c__bar',
+      };
+
+      (omniScriptTool as any).processNavigateAction(propSetMap);
+
+      expect(propSetMap['OmniScript Prefill']).to.equal('omniscript__foo=c__bar');
+    });
+
+    it('should leave Type/Sub Type/LWC OmniScript untouched when registry has no match', () => {
+      const propSetMap: any = {
+        'LWC OmniScript': 'c:unknownscriptEnglish',
+        'OmniScript Prefill': '',
+      };
+
+      (omniScriptTool as any).processNavigateAction(propSetMap);
+
+      expect(propSetMap['LWC OmniScript']).to.equal('c:unknownscriptEnglish');
+      expect(propSetMap.Type).to.equal(undefined);
+      expect(propSetMap['Sub Type']).to.equal(undefined);
+    });
+
+    it('should not throw when LWC OmniScript and OmniScript Prefill are missing or empty', () => {
+      const propSetMap: any = { someOther: 'value' };
+
+      expect(() => {
+        (omniScriptTool as any).processNavigateAction(propSetMap);
+      }).to.not.throw();
+
+      expect(propSetMap.someOther).to.equal('value');
+    });
+
+    it('should be reachable via processContentChildren dispatcher', () => {
+      const children = [
+        {
+          type: 'Navigate Action',
+          propSetMap: {
+            'LWC OmniScript': 'c:customerprofileEnglish',
+            'OmniScript Prefill': 'c__OrderNumber=%OrderNumber%',
+          },
+        },
+      ];
+
+      (omniScriptTool as any).processContentChildren(children);
+
+      expect((children[0].propSetMap as any).Type).to.equal('Customer');
+      expect((children[0].propSetMap as any)['Sub Type']).to.equal('ProfileCleaned');
+      expect((children[0].propSetMap as any).Language).to.equal('English');
+      expect((children[0].propSetMap as any)['LWC OmniScript']).to.equal('');
+      expect((children[0].propSetMap as any)['OmniScript Prefill']).to.equal('omniscript__OrderNumber=%OrderNumber%');
+    });
+  });
+
   describe('Step Action Processing', () => {
     it('should handle remoteOptions transform bundles with registry mapping', () => {
       const propSetMap = {

--- a/test/migration/omniscript-content-processing.test.ts
+++ b/test/migration/omniscript-content-processing.test.ts
@@ -309,61 +309,90 @@ describe('OmniScript Content Processing - Comprehensive Tests', () => {
   });
 
   describe('Navigate Action Processing', () => {
-    it('should resolve Type/Sub Type/Language from LWC OmniScript reference and clear LWC name', () => {
+    it('should resolve omniscript__type/subType/language from targetLWC reference', () => {
       const propSetMap: any = {
-        'LWC OmniScript': 'c:customerprofileEnglish',
-        'OmniScript Prefill': '',
-        'Page Reference Type': 'Vlocity OmniScript',
+        targetType: 'Vlocity OmniScript',
+        targetLWC: 'c:customerprofileEnglish',
+        targetLWCParams: '',
       };
 
       (omniScriptTool as any).processNavigateAction(propSetMap);
 
-      expect(propSetMap.Type).to.equal('Customer');
-      expect(propSetMap['Sub Type']).to.equal('ProfileCleaned');
-      expect(propSetMap.Language).to.equal('English');
-      expect(propSetMap['LWC OmniScript']).to.equal('');
-      expect(propSetMap['Page Reference Type']).to.equal('Vlocity OmniScript');
+      expect(propSetMap.omniscript__type).to.equal('Customer');
+      expect(propSetMap.omniscript__subType).to.equal('ProfileCleaned');
+      expect(propSetMap.omniscript__language).to.equal('English');
+      expect(propSetMap.targetLWC).to.equal('c:customerprofileEnglish');
     });
 
-    it('should rewrite c__ prefill keys to omniscript__ at key boundaries', () => {
+    it('should resolve targetLWC when the reference uses the c__ namespace prefix', () => {
       const propSetMap: any = {
-        'LWC OmniScript': '',
-        'OmniScript Prefill': 'c__OrderNumber=%OrderNumber%&c__tabLabel=Order Summary&c__tabIcon=standard:orders',
+        targetType: 'Vlocity OmniScript',
+        targetLWC: 'c__customerprofileEnglish',
+        targetLWCParams: '',
       };
 
       (omniScriptTool as any).processNavigateAction(propSetMap);
 
-      expect(propSetMap['OmniScript Prefill']).to.equal(
+      expect(propSetMap.omniscript__type).to.equal('Customer');
+      expect(propSetMap.omniscript__subType).to.equal('ProfileCleaned');
+      expect(propSetMap.omniscript__language).to.equal('English');
+    });
+
+    it('should rewrite c__ targetLWCParams keys to omniscript__ at key boundaries', () => {
+      const propSetMap: any = {
+        targetType: 'Vlocity OmniScript',
+        targetLWC: '',
+        targetLWCParams: 'c__OrderNumber=%OrderNumber%&c__tabLabel=Order Summary&c__tabIcon=standard:orders',
+      };
+
+      (omniScriptTool as any).processNavigateAction(propSetMap);
+
+      expect(propSetMap.targetLWCParams).to.equal(
         'omniscript__OrderNumber=%OrderNumber%&omniscript__tabLabel=Order Summary&omniscript__tabIcon=standard:orders'
       );
     });
 
-    it('should not rewrite c__ substrings inside prefill values', () => {
+    it('should not rewrite c__ substrings inside targetLWCParams values', () => {
       const propSetMap: any = {
-        'LWC OmniScript': '',
-        'OmniScript Prefill': 'c__foo=c__bar',
+        targetType: 'Vlocity OmniScript',
+        targetLWCParams: 'c__foo=c__bar',
       };
 
       (omniScriptTool as any).processNavigateAction(propSetMap);
 
-      expect(propSetMap['OmniScript Prefill']).to.equal('omniscript__foo=c__bar');
+      expect(propSetMap.targetLWCParams).to.equal('omniscript__foo=c__bar');
     });
 
-    it('should leave Type/Sub Type/LWC OmniScript untouched when registry has no match', () => {
+    it('should leave propertySet untouched when registry has no match', () => {
       const propSetMap: any = {
-        'LWC OmniScript': 'c:unknownscriptEnglish',
-        'OmniScript Prefill': '',
+        targetType: 'Vlocity OmniScript',
+        targetLWC: 'c:unknownscriptEnglish',
+        targetLWCParams: '',
       };
 
       (omniScriptTool as any).processNavigateAction(propSetMap);
 
-      expect(propSetMap['LWC OmniScript']).to.equal('c:unknownscriptEnglish');
-      expect(propSetMap.Type).to.equal(undefined);
-      expect(propSetMap['Sub Type']).to.equal(undefined);
+      expect(propSetMap.targetLWC).to.equal('c:unknownscriptEnglish');
+      expect(propSetMap.omniscript__type).to.equal(undefined);
+      expect(propSetMap.omniscript__subType).to.equal(undefined);
     });
 
-    it('should not throw when LWC OmniScript and OmniScript Prefill are missing or empty', () => {
-      const propSetMap: any = { someOther: 'value' };
+    it('should be a no-op when targetType is not Vlocity OmniScript', () => {
+      const propSetMap: any = {
+        targetType: 'URL',
+        targetLWC: 'c:customerprofileEnglish',
+        targetLWCParams: 'c__foo=bar',
+      };
+
+      (omniScriptTool as any).processNavigateAction(propSetMap);
+
+      expect(propSetMap.targetLWC).to.equal('c:customerprofileEnglish');
+      expect(propSetMap.targetLWCParams).to.equal('c__foo=bar');
+      expect(propSetMap.omniscript__type).to.equal(undefined);
+    });
+
+    it('should not throw when targetLWC and targetLWCParams are missing or empty', () => {
+      const propSetMap: any = { targetType: 'Vlocity OmniScript', someOther: 'value' };
 
       expect(() => {
         (omniScriptTool as any).processNavigateAction(propSetMap);
@@ -377,19 +406,19 @@ describe('OmniScript Content Processing - Comprehensive Tests', () => {
         {
           type: 'Navigate Action',
           propSetMap: {
-            'LWC OmniScript': 'c:customerprofileEnglish',
-            'OmniScript Prefill': 'c__OrderNumber=%OrderNumber%',
+            targetType: 'Vlocity OmniScript',
+            targetLWC: 'c:customerprofileEnglish',
+            targetLWCParams: 'c__OrderNumber=%OrderNumber%',
           },
         },
       ];
 
       (omniScriptTool as any).processContentChildren(children);
 
-      expect((children[0].propSetMap as any).Type).to.equal('Customer');
-      expect((children[0].propSetMap as any)['Sub Type']).to.equal('ProfileCleaned');
-      expect((children[0].propSetMap as any).Language).to.equal('English');
-      expect((children[0].propSetMap as any)['LWC OmniScript']).to.equal('');
-      expect((children[0].propSetMap as any)['OmniScript Prefill']).to.equal('omniscript__OrderNumber=%OrderNumber%');
+      expect((children[0].propSetMap as any).omniscript__type).to.equal('Customer');
+      expect((children[0].propSetMap as any).omniscript__subType).to.equal('ProfileCleaned');
+      expect((children[0].propSetMap as any).omniscript__language).to.equal('English');
+      expect((children[0].propSetMap as any).targetLWCParams).to.equal('omniscript__OrderNumber=%OrderNumber%');
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

- Added processNavigateAction handler in that resolves Type/Sub Type/Language from the legacy LWC OmniScript reference using the name registry and clears the LWC name field.
- Rewrites OmniScript Prefill keys from the managed-package c__ namespace to the standard runtime omniscript__ namespace (only at key boundaries, not inside values).
- Wired the new Navigate Action constant into the dispatcher and added 6 unit tests in covering match/no-match, prefill rewriting, and dispatcher integration.

### What issues does this PR fix or reference?
