### PR TITLE
@W-22334155 flexcard vlocity action not supported to be shown in assess

### DIFF
--- a/messages/assess.json
+++ b/messages/assess.json
@@ -107,6 +107,7 @@
   "integrationProcedureManualUpdateMessage": "All references to %s in this Integration Procedure must be manually updated after migration.",
   "duplicateCardNameMessage": "A Flexcard with the same name \"%s\" already exists after name cleaning, which could lead to conflicts during migration.",
   "lowerVersionDuplicateCardNameMessage": "A Flexcard with the name \"%s\" will not be migrated because lower version of same card will be marked as duplicate, which could lead to conflicts during migration.",
+  "vlocityActionNotSupportedMessage": "The Vlocity Action \"%s\" is not supported in standard runtime FlexCards. This FlexCard cannot be migrated automatically. Reimplement the logic using the FlexCard Action (cardAction) feature.",
   "startingCustomLabelAssessment": "Starting Custom Label assessment",
   "assessedCustomLabelsCount": "Found %s labels that need attention out of %s total",
   "customLabelAssessmentCompleted": "Custom Label assessment completed",

--- a/src/migration/flexcard.ts
+++ b/src/migration/flexcard.ts
@@ -212,6 +212,7 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
           dependenciesOS: [],
           dependenciesLWC: [],
           dependenciesApexRemoteAction: [],
+          dependenciesVlocityAction: [],
           infos: [],
           warnings: [],
           errors: [this.messages.getMessage('unexpectedError')],
@@ -244,6 +245,7 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
       dependenciesFC: [],
       dependenciesLWC: [],
       dependenciesApexRemoteAction: [],
+      dependenciesVlocityAction: [],
       infos: [],
       warnings: [],
       errors: [],
@@ -332,6 +334,7 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
     flexCardAssessmentInfo.dependenciesApexRemoteAction = [
       ...new Set(flexCardAssessmentInfo.dependenciesApexRemoteAction),
     ];
+    flexCardAssessmentInfo.dependenciesVlocityAction = [...new Set(flexCardAssessmentInfo.dependenciesVlocityAction)];
 
     return flexCardAssessmentInfo;
   }
@@ -523,6 +526,11 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
         }
 
         const stateAction = action.stateAction;
+
+        // Detect Vlocity Action (not supported in standard runtime FlexCards)
+        if (stateAction.type === Constants.VlocityAction) {
+          this.addVlocityActionDependency(stateAction, flexCardAssessmentInfo);
+        }
 
         // 1-2. Handle message.value.bundle (DataRaptor) and message.value.ipMethod (Integration Procedure)
         this.processStateActionMessageForDependencies(stateAction, flexCardAssessmentInfo);
@@ -825,6 +833,11 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
       // Process each action in the actionList
       for (const action of component.property.actionList) {
         if (action.stateAction) {
+          // Detect Vlocity Action (not supported in standard runtime FlexCards)
+          if (action.stateAction.type === Constants.VlocityAction) {
+            this.addVlocityActionDependency(action.stateAction, flexCardAssessmentInfo);
+          }
+
           // Handle message field (contains DataRaptor/IP references as JSON string)
           this.processStateActionMessageForDependencies(action.stateAction, flexCardAssessmentInfo);
 
@@ -2387,6 +2400,33 @@ export class CardMigrationTool extends BaseMigrationTool implements MigrationToo
         'Warnings'
       );
     }
+  }
+
+  /**
+   * Helper method to flag a Vlocity Action dependency during assessment.
+   * Vlocity Actions are not supported in standard runtime FlexCards, so the
+   * FlexCard cannot be auto-migrated and must be manually reimplemented using
+   * the FlexCard Action (cardAction) feature.
+   */
+  private addVlocityActionDependency(stateAction: any, flexCardAssessmentInfo: FlexCardAssessmentInfo): void {
+    const actionName: string = stateAction.name || stateAction.displayName || 'Unnamed Vlocity Action';
+    if (!flexCardAssessmentInfo.dependenciesVlocityAction.includes(actionName)) {
+      flexCardAssessmentInfo.dependenciesVlocityAction.push(actionName);
+    }
+
+    const warning = this.messages.getMessage('vlocityActionNotSupportedMessage', [actionName]);
+    if (!flexCardAssessmentInfo.warnings.includes(warning)) {
+      flexCardAssessmentInfo.warnings.push(warning);
+    }
+
+    flexCardAssessmentInfo.migrationStatus = getUpdatedAssessmentStatus(
+      flexCardAssessmentInfo.migrationStatus as
+        | 'Warnings'
+        | 'Needs manual intervention'
+        | 'Ready for migration'
+        | 'Failed',
+      'Needs manual intervention'
+    );
   }
 
   // ==================== End Assessment Helper Methods ====================

--- a/src/utils/constants/documentRegistry.ts
+++ b/src/utils/constants/documentRegistry.ts
@@ -31,5 +31,10 @@ export const documentRegistry = {
     'https://help.salesforce.com/s/articleView?id=xcloud.os_standard_set_up_your_environment_for_customizing_omniscript_elements.htm&type=5',
   customLabelMigrationErrorMessage:
     'https://help.salesforce.com/s/articleView?id=xcloud.os_migrate_oma_prereq.htm&type=5',
+<<<<<<< HEAD
   corruptedParentChildLevel: 'https://help.salesforce.com/s/articleView?id=xcloud.os_version_omniscripts.htm&type=5',
+=======
+  vlocityActionNotSupportedMessage:
+    'https://help.salesforce.com/s/articleView?id=xcloud.os_add_an_action_to_a_flexcard_25672.htm&type=5',
+>>>>>>> bbef79c (feat: adding cta link)
 };

--- a/src/utils/constants/documentRegistry.ts
+++ b/src/utils/constants/documentRegistry.ts
@@ -31,10 +31,7 @@ export const documentRegistry = {
     'https://help.salesforce.com/s/articleView?id=xcloud.os_standard_set_up_your_environment_for_customizing_omniscript_elements.htm&type=5',
   customLabelMigrationErrorMessage:
     'https://help.salesforce.com/s/articleView?id=xcloud.os_migrate_oma_prereq.htm&type=5',
-<<<<<<< HEAD
   corruptedParentChildLevel: 'https://help.salesforce.com/s/articleView?id=xcloud.os_version_omniscripts.htm&type=5',
-=======
   vlocityActionNotSupportedMessage:
     'https://help.salesforce.com/s/articleView?id=xcloud.os_add_an_action_to_a_flexcard_25672.htm&type=5',
->>>>>>> bbef79c (feat: adding cta link)
 };

--- a/src/utils/constants/stringContants.ts
+++ b/src/utils/constants/stringContants.ts
@@ -69,6 +69,8 @@ export const Constants = {
   RemoteAction: 'Remote Action',
   StepElement: 'Step',
   CustomLightningWebComponent: 'Custom Lightning Web Component',
+  NavigateAction: 'Navigate Action',
+  VlocityAction: 'Vlocity Action',
 
   // artifacts persistance folder names
   AssessmentReportsFolderName: 'assessment_reports',

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -172,6 +172,7 @@ export interface FlexCardAssessmentInfo {
   dependenciesFC: string[];
   dependenciesLWC: string[];
   dependenciesApexRemoteAction: string[];
+  dependenciesVlocityAction: string[];
   infos: string[];
   warnings: string[];
   errors: string[];

--- a/src/utils/resultsbuilder/FlexcardAssessmentReporter.ts
+++ b/src/utils/resultsbuilder/FlexcardAssessmentReporter.ts
@@ -83,6 +83,7 @@ export class FlexcardAssessmentReporter {
       { name: 'Flexcard Dependencies', colspan: 1, rowspan: 2 },
       { name: 'Remote Action Dependencies', colspan: 1, rowspan: 2 },
       { name: 'Custom LWC Dependencies', colspan: 1, rowspan: 2 },
+      { name: 'Vlocity Action Dependencies', colspan: 1, rowspan: 2 },
     ];
 
     const nameLabel = isStandardDataModel() ? 'Name' : 'Updated Name';
@@ -223,6 +224,18 @@ export class FlexcardAssessmentReporter {
           false,
           undefined,
           flexCardAssessmentInfo.dependenciesLWC
+        ),
+        createRowDataParam(
+          'vlocityActionDependencies',
+          flexCardAssessmentInfo.dependenciesVlocityAction
+            ? flexCardAssessmentInfo.dependenciesVlocityAction.join(', ')
+            : '',
+          false,
+          1,
+          1,
+          false,
+          undefined,
+          flexCardAssessmentInfo.dependenciesVlocityAction
         ),
       ],
     }));

--- a/test/migration/flexcard-standard-datamodel.test.ts
+++ b/test/migration/flexcard-standard-datamodel.test.ts
@@ -873,6 +873,117 @@ describe('FlexCard Standard Data Model (Metadata API Disabled) - Assessment and 
       expect(result.dependenciesOS).to.have.length.greaterThan(0);
       expect(result.warnings).to.have.length.greaterThan(0);
     });
+
+    it('should detect Vlocity Action in events[].actionList[].stateAction and mark for manual intervention', async () => {
+      const mockFlexCard = {
+        Id: 'fc_events_vlocity_action',
+        Name: 'EventsVlocityActionCard',
+        DataSourceConfig: JSON.stringify({ type: 'None' }),
+        PropertySetConfig: JSON.stringify({
+          layout: 'Card',
+          states: [],
+          events: [
+            {
+              actionList: [
+                {
+                  stateAction: {
+                    type: 'Vlocity Action',
+                    name: 'OpenAccountPage',
+                    displayName: 'Open Account',
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+        IsActive: true,
+        OmniUiCardType: 'Parent',
+        VersionNumber: 1,
+      };
+
+      const result = await (cardTool as any).processFlexCard(mockFlexCard, new Set<string>());
+
+      expect(result.dependenciesVlocityAction).to.include('OpenAccountPage');
+      expect(result.migrationStatus).to.equal('Needs manual intervention');
+      expect(result.warnings).to.have.length.greaterThan(0);
+    });
+
+    it('should detect Vlocity Action inside state.components[].property.actionList[].stateAction', async () => {
+      const mockFlexCard = {
+        Id: 'fc_component_vlocity_action',
+        Name: 'ComponentVlocityActionCard',
+        DataSourceConfig: JSON.stringify({ type: 'None' }),
+        PropertySetConfig: JSON.stringify({
+          layout: 'Card',
+          states: [
+            {
+              components: {
+                'block-0': {
+                  element: 'action',
+                  property: {
+                    actionList: [
+                      {
+                        stateAction: {
+                          type: 'Vlocity Action',
+                          name: 'CallAction',
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        }),
+        IsActive: true,
+        OmniUiCardType: 'Parent',
+        VersionNumber: 1,
+      };
+
+      const result = await (cardTool as any).processFlexCard(mockFlexCard, new Set<string>());
+
+      expect(result.dependenciesVlocityAction).to.include('CallAction');
+      expect(result.migrationStatus).to.equal('Needs manual intervention');
+      expect(result.warnings).to.have.length.greaterThan(0);
+    });
+
+    it('should not flag Vlocity Action when none is present', async () => {
+      const mockFlexCard = {
+        Id: 'fc_no_vlocity_action',
+        Name: 'NoVlocityActionCard',
+        DataSourceConfig: JSON.stringify({ type: 'None' }),
+        PropertySetConfig: JSON.stringify({
+          layout: 'Card',
+          states: [
+            {
+              components: {
+                'block-0': {
+                  element: 'action',
+                  property: {
+                    actionList: [
+                      {
+                        stateAction: {
+                          type: 'cardAction',
+                          eventName: 'reload',
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        }),
+        IsActive: true,
+        OmniUiCardType: 'Parent',
+        VersionNumber: 1,
+      };
+
+      const result = await (cardTool as any).processFlexCard(mockFlexCard, new Set<string>());
+
+      expect(result.dependenciesVlocityAction).to.be.an('array').that.is.empty;
+      expect(result.migrationStatus).to.equal('Ready for migration');
+    });
   });
 
   describe('Events Array Reference Handling - Migration', () => {


### PR DESCRIPTION
### What does this PR do?
Detects FlexCards using "Vlocity Action" (unsupported in standard runtime) during assessment, marking them as Needs manual intervention with a warning naming the action. The Assessment Report gains a new Vlocity Action Dependencies column listing the offending action names so customers know exactly what to reimplement using cardAction
<img width="1674" height="479" alt="Screenshot 2026-05-26 at 3 56 42 PM" src="https://github.com/user-attachments/assets/b79c609c-e727-4fbe-8995-8cf4025cec9e" />


The Vlocity action can be replaced with any of the other actions in the core. Details in https://docs.google.com/document/d/1hx70iRjk2m5fPkdm206lWc7viSC-OE7CPb_OhOnIsUE/edit?tab=t.0


### What issues does this PR fix or reference?
