### PR TITLE
fix: @W-22959073: auto-enable Pre/Post hooks for delegated classes and org-owned namespaces

### DIFF
--- a/messages/migrate.json
+++ b/messages/migrate.json
@@ -366,5 +366,6 @@
   "ossAttachmentDownloadSuccess": "Successfully downloaded attachment %s, size: %s bytes",
   "ossAttachmentDownloadFailed": "Failed to download attachment from path %s : %s",
   "flexipageOsWrapperSummary": "OmniScript component will migrate from vlocityLWCOmniWrapper to runtime_omnistudio:omniscript",
-  "flexipageFcWrapperSummary": "FlexCard component will migrate from vlocityLWCOmniWrapper to runtime_omnistudio:flexcard"
+  "flexipageFcWrapperSummary": "FlexCard component will migrate from vlocityLWCOmniWrapper to runtime_omnistudio:flexcard",
+  "corruptedParentChildLevel": "%s has elements with corrupted parent-child hierarchy. The following elements have their parent and child persisted at the same level, which will cause data loss after migration: %s. Create a new version of this %s to fix the issue before migrating."
 }

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -92,10 +92,8 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     const classes = new Set<string>();
     try {
       const objectName = `${this.namespacePrefix}CustomClassImplementation__c`;
-      console.log(`SELECT Id, Name FROM ${objectName} LIMIT 200`);
       const soql = `SELECT Id, Name FROM ${objectName} LIMIT 200`;
       const result = await this.connection.query(soql);
-      console.log('result', result);
       if (result.totalSize > 0) {
         for (const record of result.records as any[]) {
           const hookName: string = record.Name || '';
@@ -128,10 +126,8 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
   }
 
   private hasHookForClass(remoteClass: string, remoteMethod?: string): boolean {
-    console.log('hasHookForClass remoteClass', remoteClass);
     if (this.hookRegisteredClasses.size === 0 || !remoteClass) return false;
     const simpleName = remoteClass.includes('.') ? remoteClass.split('.').pop() : remoteClass;
-    console.log('simpleName', simpleName);
     if (this.hookRegisteredClasses.has(simpleName)) return true;
     // Check if remoteMethod references a hooked class via VOI pattern
     // Supports both "CpqAppHandler-getCartsItems" and "CpqAppHandler.getCartsItems" delimiters
@@ -815,7 +811,6 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     const uniqueMissingOS = [...new Set(missingOS)];
 
     if (hookEnabledSteps.length > 0 && omniProcessType === 'Integration Procedure') {
-      console.log('hookEnabledSteps', hookEnabledSteps);
       warnings.push(this.messages.getMessage('prePostHookAutoEnabled', [hookEnabledSteps.join(', ')]));
     }
 
@@ -2581,7 +2576,6 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
    * @param propSetMap Property set map from the element
    */
   private processRemoteAction(propSetMap: any): void {
-    console.log('processRemoteAction remoteClass', propSetMap.remoteClass);
     this.processTransformBundles(propSetMap);
 
     if (propSetMap.remoteClass) {
@@ -2589,7 +2583,6 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     }
 
     if (this.hasHookForClass(propSetMap.remoteClass, propSetMap.remoteMethod)) {
-      console.log('remoteClass', propSetMap.remoteClass);
       const remoteOptions = propSetMap['remoteOptions'] || {};
       remoteOptions['PreHook'] = true;
       remoteOptions['PostHook'] = true;

--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -89,11 +89,13 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
   }
 
   private async loadHookRegistrations(): Promise<Set<string>> {
+    const classes = new Set<string>();
     try {
       const objectName = `${this.namespacePrefix}CustomClassImplementation__c`;
-      const soql = `SELECT Id, Name FROM ${objectName} WHERE Name LIKE '%Hook' LIMIT 200`;
+      console.log(`SELECT Id, Name FROM ${objectName} LIMIT 200`);
+      const soql = `SELECT Id, Name FROM ${objectName} LIMIT 200`;
       const result = await this.connection.query(soql);
-      const classes = new Set<string>();
+      console.log('result', result);
       if (result.totalSize > 0) {
         for (const record of result.records as any[]) {
           const hookName: string = record.Name || '';
@@ -102,17 +104,47 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
           }
         }
       }
-      return classes;
     } catch (e) {
       Logger.warn('Unable to query CustomClassImplementation__c for hook registrations: ' + e);
-      return new Set();
     }
+
+    try {
+      const interfaceObjectName = `${this.namespacePrefix}InterfaceImplementation__c`;
+      const interfaceSoql = `SELECT Id, Name, ${this.namespacePrefix}ImplementationClassName__c FROM ${interfaceObjectName} WHERE Name LIKE '%Hook%' LIMIT 200`;
+      const interfaceResult = await this.connection.query(interfaceSoql);
+      if (interfaceResult.totalSize > 0) {
+        for (const record of interfaceResult.records as any[]) {
+          const hookName: string = record.Name || '';
+          if (hookName.endsWith('Hook')) {
+            classes.add(hookName.substring(0, hookName.length - 4));
+          }
+        }
+      }
+    } catch (e) {
+      Logger.warn('Unable to query InterfaceImplementation__c for hook registrations: ' + e);
+    }
+
+    return classes;
   }
 
-  private hasHookForClass(remoteClass: string): boolean {
+  private hasHookForClass(remoteClass: string, remoteMethod?: string): boolean {
+    console.log('hasHookForClass remoteClass', remoteClass);
     if (this.hookRegisteredClasses.size === 0 || !remoteClass) return false;
     const simpleName = remoteClass.includes('.') ? remoteClass.split('.').pop() : remoteClass;
-    return this.hookRegisteredClasses.has(simpleName);
+    console.log('simpleName', simpleName);
+    if (this.hookRegisteredClasses.has(simpleName)) return true;
+    // Check if remoteMethod references a hooked class via VOI pattern
+    // Supports both "CpqAppHandler-getCartsItems" and "CpqAppHandler.getCartsItems" delimiters
+    if (remoteMethod) {
+      let delegateClass: string | undefined;
+      if (remoteMethod.includes('-')) {
+        delegateClass = remoteMethod.split('-')[0];
+      } else if (remoteMethod.includes('.')) {
+        delegateClass = remoteMethod.split('.')[0];
+      }
+      if (delegateClass && this.hookRegisteredClasses.has(delegateClass)) return true;
+    }
+    return false;
   }
 
   getName(
@@ -553,7 +585,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
             namespaceErrors.push(this.messages.getMessage('apexClassNotFound', [className, nameVal]));
           }
         }
-        if (className && this.hasHookForClass(className)) {
+        if (className && this.hasHookForClass(className, methodName)) {
           hookEnabledSteps.push(nameVal);
         }
       }
@@ -783,6 +815,7 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
     const uniqueMissingOS = [...new Set(missingOS)];
 
     if (hookEnabledSteps.length > 0 && omniProcessType === 'Integration Procedure') {
+      console.log('hookEnabledSteps', hookEnabledSteps);
       warnings.push(this.messages.getMessage('prePostHookAutoEnabled', [hookEnabledSteps.join(', ')]));
     }
 
@@ -2548,13 +2581,15 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
    * @param propSetMap Property set map from the element
    */
   private processRemoteAction(propSetMap: any): void {
+    console.log('processRemoteAction remoteClass', propSetMap.remoteClass);
     this.processTransformBundles(propSetMap);
 
     if (propSetMap.remoteClass) {
       propSetMap.remoteClass = this.apexNamespaceRegistry.getQualifiedClassName(propSetMap.remoteClass);
     }
 
-    if (this.hasHookForClass(propSetMap.remoteClass)) {
+    if (this.hasHookForClass(propSetMap.remoteClass, propSetMap.remoteMethod)) {
+      console.log('remoteClass', propSetMap.remoteClass);
       const remoteOptions = propSetMap['remoteOptions'] || {};
       remoteOptions['PreHook'] = true;
       remoteOptions['PostHook'] = true;

--- a/src/utils/orgUtils/index.ts
+++ b/src/utils/orgUtils/index.ts
@@ -20,6 +20,7 @@ interface InstalledPackage {
 interface OrgDetails {
   Name: string;
   Id: string;
+  NamespacePrefix?: string;
 }
 
 export interface OmnistudioOrgDetails {
@@ -31,6 +32,7 @@ export interface OmnistudioOrgDetails {
   rollbackFlags?: string[];
   isFoundationPackage: boolean;
   isOmnistudioMetadataAPIEnabled: boolean;
+  isOrgOwnedNamespace?: boolean;
 }
 
 export interface PackageDetail {
@@ -276,7 +278,7 @@ export class OrgUtils {
   private static readonly objectName = 'Publisher';
 
   // Define the fields to retrieve from the Organization object
-  private static readonly orgFields = ['Name'];
+  private static readonly orgFields = ['Name', 'NamespacePrefix'];
 
   // Define the object name for querying installed packages
   private static readonly orgObjectName = 'Organization';
@@ -314,6 +316,8 @@ export class OrgUtils {
       version: '',
       namespace: '',
     };
+
+    let isOrgOwnedNamespace = false;
 
     const installedOmniPackages = [];
     for (const pkg of allInstalledPackages) {
@@ -357,16 +361,27 @@ export class OrgUtils {
       packageDetails.version = `${pkg.MajorVersion}.${pkg.MinorVersion}`;
       packageDetails.namespace = pkg.NamespacePrefix;
     } else {
-      // return to validate the org information
-      return {
-        packageDetails: undefined,
-        omniStudioOrgPermissionEnabled: false,
-        orgDetails: orgDetails[0],
-        dataModel: undefined,
-        hasValidNamespace: false,
-        isFoundationPackage: false,
-        isOmnistudioMetadataAPIEnabled: false,
-      };
+      // No packages found in Publisher object - check if org has a registered namespace
+      const orgNamespace = orgDetails[0]?.NamespacePrefix;
+      if (orgNamespace && this.namespaces.has(orgNamespace)) {
+        // Org has a valid Omnistudio namespace registered
+        packageDetails.namespace = orgNamespace;
+        packageDetails.version = '0.0'; // Version unknown for org-owned namespace
+        isOrgOwnedNamespace = true;
+        Logger.log(`Using org-registered namespace: ${orgNamespace} (no managed package installed)`);
+      } else {
+        // return to validate the org information
+        return {
+          packageDetails: undefined,
+          omniStudioOrgPermissionEnabled: false,
+          orgDetails: orgDetails[0],
+          dataModel: undefined,
+          hasValidNamespace: false,
+          isFoundationPackage: false,
+          isOmnistudioMetadataAPIEnabled: false,
+          isOrgOwnedNamespace: false,
+        };
+      }
     }
 
     //Execute apex rest resource to get omnistudio org permission
@@ -399,6 +414,7 @@ export class OrgUtils {
       hasValidNamespace: hasValidNamespace,
       isFoundationPackage: isFoundationPackage,
       isOmnistudioMetadataAPIEnabled: isOmnistudioMetadataAPIEnabled,
+      isOrgOwnedNamespace: isOrgOwnedNamespace,
     };
   }
 

--- a/src/utils/validatorService.ts
+++ b/src/utils/validatorService.ts
@@ -39,9 +39,15 @@ export class ValidatorService {
     }
 
     // For custom data model, validate if licenses are valid
-    // Skip license check during assessment
+    // Skip license check during assessment or for org-owned namespaces
     if (isAssessment) {
       Logger.logVerbose(this.messages.getMessage('skippingLicenseCheckForAssessment'));
+      return true;
+    }
+
+    // Skip license check for org-owned namespaces (developer orgs building with the namespace)
+    if (this.orgs.isOrgOwnedNamespace) {
+      Logger.logVerbose('Skipping license check for org-owned namespace');
       return true;
     }
 

--- a/test/migration/omniscript.test.ts
+++ b/test/migration/omniscript.test.ts
@@ -67,13 +67,14 @@ describe('OmniScriptMigrationTool - Remote Action PreHook/PostHook', () => {
   function createRemoteActionElement(
     namespace: string,
     remoteOptions: Record<string, any> = {},
-    remoteClass: string = 'CpqAppHandler'
+    remoteClass: string = 'CpqAppHandler',
+    remoteMethod?: string
   ): Record<string, any> {
     const prefix = namespace ? namespace + '__' : '';
     return {
       Id: 'elemId001',
       [`${prefix}Type__c`]: 'Remote Action',
-      [`${prefix}PropertySet__c`]: JSON.stringify({ remoteOptions, remoteClass }),
+      [`${prefix}PropertySet__c`]: JSON.stringify({ remoteOptions, remoteClass, remoteMethod }),
       [`${prefix}OmniScriptId__c`]: 'osId001',
       [`${prefix}Level__c`]: 0,
       [`${prefix}ParentElementId__c`]: null,
@@ -498,6 +499,174 @@ describe('OmniScriptMigrationTool - Remote Action PreHook/PostHook', () => {
       const propertySet = JSON.parse(capturedElements[0].PropertySetConfig);
       expect(propertySet.remoteOptions).to.not.have.property('PreHook');
       expect(propertySet.remoteOptions).to.not.have.property('PostHook');
+
+      createStub.restore();
+      createOneStub.restore();
+    });
+  });
+
+  describe('migrate() when remoteClass is not registered but remoteMethod references a hooked class', () => {
+    // remoteClass = the concrete implementation (no hook registered for it), while remoteMethod
+    // encodes the hooked handler as "<Handler><delimiter>method" (VOI pattern).
+    async function runMigrateForRemoteMethod(remoteMethod: string): Promise<Record<string, any>> {
+      const namespace = 'vlocity_ins';
+      const tool = createTool(namespace);
+
+      mockConnection.query.callsFake((soql: string) => {
+        if (soql.includes('CustomClassImplementation__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [{ Id: 'hookId001', Name: 'CpqAppHandlerHook' }],
+            done: true,
+          });
+        }
+        if (soql.includes('OmniScript__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [
+              {
+                Id: 'osId001',
+                [`${namespace}__Type__c`]: 'TestType',
+                [`${namespace}__SubType__c`]: 'TestSubType',
+                [`${namespace}__Language__c`]: 'English',
+                [`${namespace}__Version__c`]: 1,
+                [`${namespace}__IsActive__c`]: false,
+                [`${namespace}__IsProcedure__c`]: true,
+              },
+            ],
+          });
+        }
+        if (soql.includes('Element__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [createRemoteActionElement(namespace, {}, 'CustomCpqAppHandlerImplementation', remoteMethod)],
+          });
+        }
+        if (soql.includes('OmniScriptDefinition__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      });
+
+      const { NetUtils } = require('../../src/utils/net');
+      const createStub = sandbox.stub(NetUtils, 'create');
+      const createOneStub = sandbox.stub(NetUtils, 'createOne');
+      createOneStub.resolves({ id: 'newOsId001', success: true, errors: [], warnings: [] });
+
+      let capturedElements: any[] = [];
+      createStub.callsFake((_conn: any, objectName: string, records: any[]) => {
+        if (objectName === 'OmniProcessElement') {
+          capturedElements = records;
+        }
+        const resultMap = new Map();
+        for (const rec of records) {
+          resultMap.set(rec.attributes.referenceId, {
+            id: 'new_' + rec.attributes.referenceId,
+            success: true,
+            errors: [],
+          });
+        }
+        return Promise.resolve(resultMap);
+      });
+
+      try {
+        await tool.migrate();
+        expect(capturedElements).to.have.lengthOf(1);
+        return JSON.parse(capturedElements[0].PropertySetConfig).remoteOptions;
+      } finally {
+        createStub.restore();
+        createOneStub.restore();
+      }
+    }
+
+    it('should enable PreHook/PostHook when remoteMethod uses the "-" delimiter (Handler-method)', async () => {
+      const remoteOptions = await runMigrateForRemoteMethod('CpqAppHandler-getCartsItems');
+      expect(remoteOptions.PreHook).to.equal(true);
+      expect(remoteOptions.PostHook).to.equal(true);
+    });
+
+    it('should enable PreHook/PostHook when remoteMethod uses the "." delimiter (Handler.method)', async () => {
+      const remoteOptions = await runMigrateForRemoteMethod('CpqAppHandler.getCartsItems');
+      expect(remoteOptions.PreHook).to.equal(true);
+      expect(remoteOptions.PostHook).to.equal(true);
+    });
+
+    it('should not enable hooks when neither remoteClass nor remoteMethod references a hooked class', async () => {
+      const remoteOptions = await runMigrateForRemoteMethod('SomeOtherHandler-doWork');
+      expect(remoteOptions).to.not.have.property('PreHook');
+      expect(remoteOptions).to.not.have.property('PostHook');
+    });
+  });
+
+  describe('migrate() with hook registered in InterfaceImplementation__c', () => {
+    it('should set PreHook=true and PostHook=true when the hook lives in InterfaceImplementation__c', async () => {
+      const namespace = 'vlocity_ins';
+      const tool = createTool(namespace);
+
+      mockConnection.query.callsFake((soql: string) => {
+        // No hook in CustomClassImplementation__c; the hook is registered in InterfaceImplementation__c
+        if (soql.includes('CustomClassImplementation__c')) {
+          return Promise.resolve({ totalSize: 0, records: [], done: true });
+        }
+        if (soql.includes('InterfaceImplementation__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [{ Id: 'hookId002', Name: 'CpqAppHandlerHook' }],
+            done: true,
+          });
+        }
+        if (soql.includes('OmniScript__c')) {
+          return Promise.resolve({
+            totalSize: 1,
+            records: [
+              {
+                Id: 'osId001',
+                [`${namespace}__Type__c`]: 'TestType',
+                [`${namespace}__SubType__c`]: 'TestSubType',
+                [`${namespace}__Language__c`]: 'English',
+                [`${namespace}__Version__c`]: 1,
+                [`${namespace}__IsActive__c`]: false,
+                [`${namespace}__IsProcedure__c`]: true,
+              },
+            ],
+          });
+        }
+        if (soql.includes('Element__c')) {
+          return Promise.resolve({ totalSize: 1, records: [createRemoteActionElement(namespace)] });
+        }
+        if (soql.includes('OmniScriptDefinition__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      });
+
+      const { NetUtils } = require('../../src/utils/net');
+      const createStub = sandbox.stub(NetUtils, 'create');
+      const createOneStub = sandbox.stub(NetUtils, 'createOne');
+      createOneStub.resolves({ id: 'newOsId001', success: true, errors: [], warnings: [] });
+
+      let capturedElements: any[] = [];
+      createStub.callsFake((_conn: any, objectName: string, records: any[]) => {
+        if (objectName === 'OmniProcessElement') {
+          capturedElements = records;
+        }
+        const resultMap = new Map();
+        for (const rec of records) {
+          resultMap.set(rec.attributes.referenceId, {
+            id: 'new_' + rec.attributes.referenceId,
+            success: true,
+            errors: [],
+          });
+        }
+        return Promise.resolve(resultMap);
+      });
+
+      await tool.migrate();
+
+      expect(capturedElements).to.have.lengthOf(1);
+      const propertySet = JSON.parse(capturedElements[0].PropertySetConfig);
+      expect(propertySet.remoteOptions.PreHook).to.equal(true);
+      expect(propertySet.remoteOptions.PostHook).to.equal(true);
 
       createStub.restore();
       createOneStub.restore();

--- a/test/utils/validatorService.test.ts
+++ b/test/utils/validatorService.test.ts
@@ -1371,4 +1371,61 @@ describe('ValidatorService', () => {
       expect(loggerErrorStub.firstCall.args[0]).to.equal('DR versioning is enabled');
     });
   });
+
+  describe('validate with org-owned namespace', () => {
+    it('should skip the license check in migration mode when isOrgOwnedNamespace is true', async () => {
+      // Arrange: custom data model, migration mode, no managed package but org owns the namespace
+      const orgs: OmnistudioOrgDetails = {
+        hasValidNamespace: true,
+        packageDetails: { namespace: 'devops001gs0' },
+        omniStudioOrgPermissionEnabled: false,
+        isFoundationPackage: false,
+        isOrgOwnedNamespace: true,
+      } as OmnistudioOrgDetails;
+      sandbox.stub(OrgPreferences, 'checkDRVersioning').resolves(false);
+      (messages.getMessage as sinon.SinonStub)
+        .withArgs('validatingDrVersioningDisabled')
+        .returns('Validating DR versioning disabled');
+      (messages.getMessage as sinon.SinonStub).withArgs('drVersioningDisabled').returns('DR versioning is disabled');
+      isStandardDataModelStub.returns(false); // Custom data model
+      const validator = new ValidatorService(orgs, messages, connection);
+
+      // Act
+      const result = await validator.validate(false); // isAssessment = false (migration mode)
+
+      // Assert
+      expect(result).to.be.true; // Passes without an OmniStudio license
+      expect(loggerLogVerboseStub.calledWith('Skipping license check for org-owned namespace')).to.be.true;
+      // No license query should be issued (DR versioning uses OrgPreferences, which is stubbed)
+      expect((connection.query as sinon.SinonStub).called).to.be.false;
+    });
+
+    it('should still run the license check in migration mode when isOrgOwnedNamespace is false', async () => {
+      // Arrange
+      const orgs: OmnistudioOrgDetails = {
+        hasValidNamespace: true,
+        packageDetails: { namespace: 'TestNamespace' },
+        omniStudioOrgPermissionEnabled: false,
+        isFoundationPackage: false,
+        isOrgOwnedNamespace: false,
+      } as OmnistudioOrgDetails;
+      const queryResult = { records: [{ total: '5' }] };
+      (connection.query as sinon.SinonStub).resolves(queryResult);
+      sandbox.stub(OrgPreferences, 'checkDRVersioning').resolves(false);
+      (messages.getMessage as sinon.SinonStub)
+        .withArgs('validatingDrVersioningDisabled')
+        .returns('Validating DR versioning disabled');
+      (messages.getMessage as sinon.SinonStub).withArgs('drVersioningDisabled').returns('DR versioning is disabled');
+      isStandardDataModelStub.returns(false); // Custom data model
+      const validator = new ValidatorService(orgs, messages, connection);
+
+      // Act
+      const result = await validator.validate(false); // isAssessment = false (migration mode)
+
+      // Assert
+      expect(result).to.be.true;
+      expect((connection.query as sinon.SinonStub).calledOnce).to.be.true; // License query SHOULD run
+      expect(loggerLogVerboseStub.calledWith('Skipping license check for org-owned namespace')).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION


### What does this PR do?
Pre/Post hook auto-enable was only working when remoteClass was exactly CpqAppHandler. Turns out a lot of Remote Actions set remoteClass to the implementation class and put the actual handler in remoteMethod instead (e.g. CpqAppHandler-getCartsItems), so those were getting skipped. Added a fallback to check remoteMethod too, and also look at InterfaceImplementation__c for hook registrations, not just CustomClassImplementation__c.

Added tests 

### What issues does this PR fix or reference?
W-22959073
