### PR TITLE
@W-23350132 - fix: skip hook registration queries on Foundation Package Orgs

### DIFF
--- a/src/migration/omniscript.ts
+++ b/src/migration/omniscript.ts
@@ -39,7 +39,11 @@ import { StringVal } from '../utils/StringValue/stringval';
 import { Logger } from '../utils/logger';
 import { createProgressBar } from './base';
 import { StorageUtil } from '../utils/storageUtil';
-import { isStandardDataModel, isStandardDataModelWithMetadataAPIEnabled } from '../utils/dataModelService';
+import {
+  isFoundationPackage,
+  isStandardDataModel,
+  isStandardDataModelWithMetadataAPIEnabled,
+} from '../utils/dataModelService';
 import { prioritizeCleanNamesFirst } from '../utils/recordPrioritization';
 import { Constants } from '../utils/constants/stringContants';
 import { ApexNamespaceRegistry, ApexResolveStatus } from './ApexNamespaceRegistry';
@@ -90,6 +94,17 @@ export class OmniScriptMigrationTool extends BaseMigrationTool implements Migrat
 
   private async loadHookRegistrations(): Promise<Set<string>> {
     const classes = new Set<string>();
+
+    // CustomClassImplementation__c and InterfaceImplementation__c ship only in the
+    // Vlocity vertical managed packages (vlocity_cmt, vlocity_ins, vlocity_ps). The
+    // OmniStudio Foundation Package (namespace omnistudio) does not provision these
+    // objects, and Core-side PlatformInvokeServiceImpl filters omnistudio /
+    // omnistudiocore out of hook orchestration. Skip the queries on Foundation orgs
+    // so we don't emit spurious INVALID_TYPE warnings during assess.
+    if (isFoundationPackage()) {
+      return classes;
+    }
+
     try {
       const objectName = `${this.namespacePrefix}CustomClassImplementation__c`;
       const soql = `SELECT Id, Name FROM ${objectName} LIMIT 200`;

--- a/test/migration/omniscript.test.ts
+++ b/test/migration/omniscript.test.ts
@@ -428,6 +428,52 @@ describe('OmniScriptMigrationTool - Remote Action PreHook/PostHook', () => {
     });
   });
 
+  describe('loadHookRegistrations() on Foundation Package orgs', () => {
+    it('should skip both CustomClassImplementation__c and InterfaceImplementation__c queries', async () => {
+      // Re-initialize DataModelService with isFoundationPackage=true to mimic an
+      // "SDM + OmniStudio Foundation Package" org (W-23350132 repro).
+      initializeDataModelService({
+        packageDetails: { version: '1.0.0', namespace: 'omnistudio' },
+        omniStudioOrgPermissionEnabled: true,
+        orgDetails: { Name: 'Test Org', Id: '00D000000000000' },
+        dataModel: 'Standard',
+        hasValidNamespace: true,
+        isFoundationPackage: true,
+        isOmnistudioMetadataAPIEnabled: true,
+      } as any);
+
+      const namespace = 'omnistudio';
+      const tool = createTool(namespace);
+
+      mockConnection.query.callsFake((soql: string) => {
+        if (soql.includes('CustomClassImplementation__c') || soql.includes('InterfaceImplementation__c')) {
+          // These queries must NOT run on Foundation orgs.
+          return Promise.reject(new Error('Unexpected hook-registration query on Foundation org'));
+        }
+        if (soql.includes('OmniScript__c')) {
+          return Promise.resolve({ totalSize: 0, records: [] });
+        }
+        return Promise.resolve({ totalSize: 0, records: [] });
+      });
+
+      // Invoke the private method directly via bracket access — a full migrate() run
+      // needs a large amount of scaffolding and this test only cares about the guard.
+      const result: Set<string> = await (tool as any).loadHookRegistrations();
+
+      expect(result.size).to.equal(0);
+      const hookQueryCalls = mockConnection.query
+        .getCalls()
+        .filter(
+          (call: sinon.SinonSpyCall) =>
+            typeof call.args[0] === 'string' &&
+            (call.args[0].includes('CustomClassImplementation__c') ||
+              call.args[0].includes('InterfaceImplementation__c'))
+        );
+      expect(hookQueryCalls).to.have.lengthOf(0);
+      expect((Logger.warn as sinon.SinonStub).called).to.equal(false);
+    });
+  });
+
   describe('migrate() when CustomClassImplementation__c query fails', () => {
     it('should default to false and not set hooks', async () => {
       const namespace = 'vlocity_ins';


### PR DESCRIPTION
CustomClassImplementation__c and InterfaceImplementation__c ship only in the Vlocity vertical managed packages (vlocity_cmt, vlocity_ins, vlocity_ps). The OmniStudio Foundation Package (namespace omnistudio) does not provision these objects. Running the assess command on an SDM + Foundation Package org therefore emits a confusing "INVALID_TYPE" warning and silently loses hook detection, which would prevent auto-enabling preTransformBundle / postTransformBundle on migrated Remote Action steps.

Gate loadHookRegistrations() on isFoundationPackage(), matching the pattern used elsewhere in the codebase (globalautonumber.ts, assess.ts, migrate.ts) and mirroring Core-side PlatformInvokeServiceImpl which filters omnistudio / omnistudiocore out of hook orchestration by design.

### What does this PR do?

### What issues does this PR fix or reference?
